### PR TITLE
Bogus Implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :development, :test do
   gem 'jettywrapper'
   gem 'dotenv-rails'
   gem 'warden-rspec-rails', :github => "mspanc/warden-rspec-rails"
+  gem "bogus"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     awesome_print (1.2.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    bogus (0.1.5)
+      dependor (>= 0.0.4)
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     builder (3.2.2)
@@ -111,6 +113,7 @@ GEM
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
+    dependor (1.0.1)
     deprecation (0.1.0)
       activesupport
     diff-lcs (1.2.5)
@@ -409,6 +412,7 @@ DEPENDENCIES
   active-triples!
   autoprefixer-rails
   awesome_print
+  bogus
   bootstrap-sass (~> 3.3.1)
   capistrano (~> 2.0)
   capybara-screenshot

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,6 @@ class ApplicationController < ActionController::Base
   before_filter :authenticate
   before_filter :authorize
 
-  private
-  
   def authenticate
     unless github_authenticated?
       github_authenticate!

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,5 +1,3 @@
-require 'json/ld'
-
 class TermsController < ApplicationController
   before_filter :load_term, :only => :show
   before_filter :vocabulary, :only => :new

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -1,4 +1,5 @@
 class TermsController < ApplicationController
+  attr_writer :term, :vocabulary
   before_filter :load_term, :only => :show
   before_filter :vocabulary, :only => :new
   rescue_from ActiveTriples::NotFound, :with => :render_404
@@ -28,15 +29,15 @@ class TermsController < ApplicationController
     end
 
     def failure(term, vocabulary)
-      __getobj__.instance_variable_set(:@term, term)
-      __getobj__.instance_variable_set(:@vocabulary, vocabulary)
+      self.term = term
+      self.vocabulary = vocabulary
       render "new"
     end
 
   end
 
   def load_term
-    @term = Term.find(params[:id])
+    self.term = Term.find(params[:id])
   end
 
   def render_404

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -2,7 +2,8 @@ require 'json/ld'
 
 class TermsController < ApplicationController
   before_filter :load_term, :only => :show
-  before_filter :find_vocabulary, :only => :new
+  before_filter :vocabulary, :only => :new
+  rescue_from ActiveTriples::NotFound, :with => :render_404
 
   def show
     respond_to do |format|
@@ -30,14 +31,14 @@ class TermsController < ApplicationController
 
     def failure(term, vocabulary)
       __getobj__.instance_variable_set(:@term, term)
+      __getobj__.instance_variable_set(:@vocabulary, vocabulary)
       render "new"
     end
 
   end
 
   def load_term
-    @term = Term.new(params[:id])
-    @term.persisted? or render_404
+    @term = Term.find(params[:id])
   end
 
   def render_404
@@ -47,11 +48,7 @@ class TermsController < ApplicationController
     end
   end
 
-  def find_vocabulary
-    raise ActionController::RoutingError.new("Term not found") unless vocabulary.persisted?
-  end
-  
   def vocabulary
-    @vocabulary ||= Vocabulary.new(params[:vocabulary_id])
+    @vocabulary ||= Vocabulary.find(params[:vocabulary_id])
   end
 end

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -1,4 +1,5 @@
 class VocabulariesController < ApplicationController
+  attr_writer :vocabulary
   before_filter :load_vocab, :only => :show
 
   def index
@@ -19,7 +20,7 @@ class VocabulariesController < ApplicationController
     end
 
     def failure(vocabulary)
-      __getobj__.instance_variable_set(:@vocabulary, vocabulary)
+      self.vocabulary = vocabulary
       render :new
     end
   end

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -1,5 +1,3 @@
-require 'json/ld'
-
 class VocabulariesController < ApplicationController
   before_filter :load_vocab, :only => :show
 

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -1,4 +1,5 @@
 class Term < ActiveTriples::Resource
+  include ActiveTriplesAdapter
   configure :repository => :default
   configure :base_uri => "http://#{Rails.application.routes.default_url_options[:host]}/ns/"
   property :comment, :predicate => RDF::RDFS.comment

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -20,6 +20,14 @@ class Term < ActiveTriples::Resource
     type.include?(Vocabulary.type)
   end
 
+  def add_error(attribute, reason)
+    errors.add(attribute, reason)
+  end
+
+  def empty_errors?
+    errors.empty?
+  end
+
   private
 
   def not_blank_node

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -11,6 +11,13 @@ class Term < ActiveTriples::Resource
 
   validate :not_blank_node
 
+  def initialize(*args)
+    id = args.pop
+    id = id.to_s.gsub(/\/$/,'')
+    args = [id] + args
+    super(*args)
+  end
+
   def id
     return nil if rdf_subject.node?
     rdf_subject.to_s.gsub(self.class.base_uri,"")

--- a/app/services/term_creator.rb
+++ b/app/services/term_creator.rb
@@ -52,7 +52,7 @@ class TermCreator
   end
 
   def check_term_persistence
-    term.errors.add(:id, "already exists in the repository") if term.persisted?
+    term.errors.add(:id, "already exists in the repository") if Term.exists?(term_id)
   end
 
   def notify_callbacks

--- a/app/services/term_creator.rb
+++ b/app/services/term_creator.rb
@@ -40,24 +40,24 @@ class TermCreator
   end
 
   def persist_term
-    term.persist!(:validate => true) if term.errors.empty?
+    term.persist!(:validate => true) if term.empty_errors?
   end
 
   def check_nonempty_id
-    term.errors.add(:id, "can not be blank") unless term_id.present?
+    term.add_error(:id, "can not be blank") unless term_id.present?
   end
 
   def check_vocabulary_persistence
-    term.errors.add(:id, "is in a non-existent vocabulary") unless vocabulary.persisted?
+    term.add_error(:id, "is in a non-existent vocabulary") unless vocabulary.persisted?
   end
 
   def check_term_persistence
-    term.errors.add(:id, "already exists in the repository") if Term.exists?(term.id)
+    term.add_error(:id, "already exists in the repository") if Term.exists?(term.id)
   end
 
   def notify_callbacks
     callbacks.each do |callback|
-      if term.errors.empty?
+      if term.empty_errors?
         callback.success(term, vocabulary)
       else
         callback.failure(term, vocabulary)

--- a/app/services/term_creator.rb
+++ b/app/services/term_creator.rb
@@ -52,7 +52,7 @@ class TermCreator
   end
 
   def check_term_persistence
-    term.errors.add(:id, "already exists in the repository") if Term.exists?(term_id)
+    term.errors.add(:id, "already exists in the repository") if Term.exists?(term.id)
   end
 
   def notify_callbacks

--- a/app/services/vocabulary_creator.rb
+++ b/app/services/vocabulary_creator.rb
@@ -45,14 +45,14 @@ class VocabularyCreator
   end
 
   def check_existence
-    vocabulary.errors.add(:id, "already exists in the repository") if Vocabulary.exists?(vocabulary.id)
+    vocabulary.add_error(:id, "already exists in the repository") if Vocabulary.exists?(vocabulary.id)
   end
 
   def persist_vocabulary
     # This return is a hack. Checking #valid? clears out errors and re-runs
     # validations, which means the above doesn't work. Need a better way to do
     # this maybe. A decorator with validators maybe?
-    return unless vocabulary.errors.empty?
+    return unless vocabulary.empty_errors?
     @result = vocabulary.persist!(:validate => true)
   end
 

--- a/app/services/vocabulary_creator.rb
+++ b/app/services/vocabulary_creator.rb
@@ -45,7 +45,7 @@ class VocabularyCreator
   end
 
   def check_existence
-    vocabulary.errors.add(:id, "already exists in the repository") if vocabulary.persisted?
+    vocabulary.errors.add(:id, "already exists in the repository") if Vocabulary.exists?(vocabulary.id)
   end
 
   def persist_vocabulary

--- a/app/views/terms/_form_id.html.erb
+++ b/app/views/terms/_form_id.html.erb
@@ -1,0 +1,5 @@
+<%= f.input :id, :wrapper => :vertical_input_group, :label => "ID" do %>
+  <span class="input-group-addon"><%= @vocabulary.rdf_subject.to_s %>/</span>
+  <%= f.input_field :id, :class => "form-control", :value => @term.id.to_s.gsub(/^#{@vocabulary.id}\//,'') %>
+  <%= hidden_field_tag 'vocabulary_id', @vocabulary.id %>
+<% end %>

--- a/app/views/terms/new.html.erb
+++ b/app/views/terms/new.html.erb
@@ -1,11 +1,7 @@
 <h1>Create New Term</h1>
 
 <%= simple_form_for(@term) do |f| %>
-  <%= f.input :id, :wrapper => :vertical_input_group, :label => "ID" do %>
-    <span class="input-group-addon"><%= @vocabulary.rdf_subject.to_s %>/</span>
-    <%= f.input_field :id, :class => "form-control", :value => @term.id.to_s.gsub(/^#{@vocabulary.id}\//,'') %>
-    <%= hidden_field_tag 'vocabulary_id', @vocabulary.id %>
-  <% end %>
+  <%= render "form_id", :f => f %>
   <% %w{label comment}.each do |attribute| %>
     <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => @term, :attribute => attribute, :form => f} %>
   <% end %>

--- a/app/views/terms/new.html.erb
+++ b/app/views/terms/new.html.erb
@@ -1,13 +1,13 @@
 <h1>Create New Term</h1>
 
-<%= simple_form_for(@term, :url => terms_path, :method => :post) do |f| %>
+<%= simple_form_for(@term) do |f| %>
   <%= f.input :id, :wrapper => :vertical_input_group, :label => "ID" do %>
     <span class="input-group-addon"><%= @vocabulary.rdf_subject.to_s %>/</span>
-    <%= f.input_field :id, :class => "form-control" %>
+    <%= f.input_field :id, :class => "form-control", :value => @term.id.to_s.gsub(/^#{@vocabulary.id}\//,'') %>
     <%= hidden_field_tag 'vocabulary_id', @vocabulary.id %>
   <% end %>
   <% %w{label comment}.each do |attribute| %>
     <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => @term, :attribute => attribute, :form => f} %>
   <% end %>
-  <%= f.button :submit, "Create Term" %>
+  <%= f.button :submit %>
 <% end %>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(vocabulary, :url => vocabularies_path, :method => method) do |f| %>
+<%= simple_form_for(vocabulary) do |f| %>
   <%= f.error_notification %>
 
   <div class="form-inputs">
@@ -8,6 +8,6 @@
   </div>
 
   <div class="form-actions">
-    <%= f.button :submit, button_text %>
+    <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/vocabularies/new.html.erb
+++ b/app/views/vocabularies/new.html.erb
@@ -1,3 +1,3 @@
 <h1> Create New Vocabulary </h1>
 
-<%= render :partial => "form", :locals => { :vocabulary => @vocabulary, :method => :post, :button_text => "Create Vocabulary" } %>
+<%= render :partial => "form", :locals => { :vocabulary => @vocabulary } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module ControlledVocabularyManager
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     Rails.application.routes.default_url_options[:host] = 'opaquenamespace.org'
+    config.autoload_paths += %W(#{config.root}/lib)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require 'json/ld'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/lib/active_triples/not_found.rb
+++ b/lib/active_triples/not_found.rb
@@ -1,0 +1,3 @@
+class ActiveTriples::NotFound < StandardError
+
+end

--- a/lib/active_triples_adapter.rb
+++ b/lib/active_triples_adapter.rb
@@ -14,6 +14,15 @@ module ActiveTriplesAdapter
       raise ActiveTriples::NotFound if result.statements.to_a.length == 0
       result
     end
+
+    def exists?(uri)
+      begin
+        find(uri)
+      rescue ActiveTriples::NotFound
+        return false
+      end
+      true
+    end
   end
 
 end

--- a/lib/active_triples_adapter.rb
+++ b/lib/active_triples_adapter.rb
@@ -11,7 +11,11 @@ module ActiveTriplesAdapter
     def find(uri)
       result = new(uri)
       result.orig_reload
-      raise ActiveTriples::NotFound if result.statements.to_a.length == 0
+      relevant_triples = result.statements.to_a
+      if type
+        relevant_triples.select!{|x| !(x.predicate == RDF.type && x.object.to_s == type.to_s)}
+      end
+      raise ActiveTriples::NotFound if relevant_triples.length == 0
       result
     end
 

--- a/lib/active_triples_adapter.rb
+++ b/lib/active_triples_adapter.rb
@@ -1,0 +1,19 @@
+module ActiveTriplesAdapter
+  extend ActiveSupport::Concern
+  included do
+    alias_method :orig_reload, :reload
+    def reload
+    end
+  end
+
+
+  module ClassMethods
+    def find(uri)
+      result = new(uri)
+      result.orig_reload
+      raise ActiveTriples::NotFound if result.statements.to_a.length == 0
+      result
+    end
+  end
+
+end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -117,6 +117,18 @@ RSpec.describe TermsController do
       expect(TermCreator).to receive(:call).with(params[:term], vocabulary, [create_responder])
       post :create, params
     end
+    context "when vocabulary isn't found" do
+      before do
+        allow(Vocabulary).to receive(:find).and_raise ActiveTriples::NotFound
+      end
+      it "should return a 404" do
+        expect(post(:create, params).code).to eq "404"
+      end
+      it "doesn't call TermCreator" do
+        expect(TermCreator).not_to receive(:call)
+        post :create, params
+      end
+    end
     describe "CreateResponder" do
       let(:term) { Term.new }
       let(:term_id) { "bla/bla" }

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TermsController do
     end
     context "when the vocabulary is not persisted" do
       before do
-        allow(Vocabulary).to receive(:find).with(vocabulary.id).and_raise ActiveTriples::NotFound
+        expect(Vocabulary).to receive(:find).with(vocabulary.id).and_raise ActiveTriples::NotFound
       end
       it "should raise a 404" do
         expect(get_new.code).to eq "404"

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.describe VocabulariesController do
   describe "GET 'new'" do
+    fake(:vocabulary)
     let(:result) { get 'new' }
     before do
+      stub(Vocabulary).new { vocabulary }
       result
     end
     it "should be successful" do
       expect(result).to be_success
     end
     it "assigns @vocabulary" do
-      assigned = assigns(:vocabulary)
-      expect(assigned).to be_kind_of Vocabulary
-      expect(assigned).to be_new_record
+      expect(assigns(:vocabulary)).to eq vocabulary
     end
     it "renders new" do
       expect(result).to render_template("new")
@@ -32,58 +32,56 @@ RSpec.describe VocabulariesController do
   end
 
   describe "POST create" do
+    fake(:vocabulary)
+    fake(:term_callback)
     let(:vocabulary_params) do
       {
-        :label => ["Test1"],
-        :comment => ["Test2"]
+        "label" => ["Test1"],
+        "comment" => ["Test2"]
       }
     end
-    let(:vocabulary) { instance_double("Vocabulary") }
     let(:result) { post 'create', :vocabulary => vocabulary_params }
-    let(:responder_class) {class_double("VocabulariesController::CreateResponder").as_stubbed_const}
-    let(:responder) {instance_double("VocabulariesController::CreateResponder")}
     before do
-      expect(VocabulariesController::CreateResponder).to receive(:new).with(controller).and_return(responder)
-      allow(VocabularyCreator).to receive(:call)
-      allow(controller).to receive(:render)
+      stub(VocabulariesController::CreateResponder).new(controller) { term_callback }
+      stub(VocabularyCreator).call(any_args) do
+        controller.render :nothing => true
+      end
       result
     end
     it "should call vocabulary creator" do
-      expect(VocabularyCreator).to have_received(:call).with(vocabulary_params, responder)
+      expect(VocabularyCreator).to have_received.call(vocabulary_params, term_callback)
     end
   end
 
   describe "Create Responder" do
     subject { VocabulariesController::CreateResponder.new(controller) }
-    let(:vocabulary) { Vocabulary.new }
+    let(:vocabulary) { Vocabulary.new("Creator") }
     let(:result) { post 'create', :vocabulary => {} }
+    before do
+      stub(vocabulary).persisted? { true }
+    end
     describe "#success" do
       before do
-        allow(VocabularyCreator).to receive(:call) do
+        stub(controller).create do
           subject.success(vocabulary)
         end
-        allow(vocabulary).to receive(:id).and_return("1")
-        allow(vocabulary).to receive(:persisted?).and_return(true)
         result
       end
       it "should redirect" do
-        expect(response).to redirect_to "/ns/1"
+        expect(response).to redirect_to "/ns/Creator"
       end
     end
     describe "#failure" do
       before do
-        allow(VocabularyCreator).to receive(:call) do
+        stub(controller).create do
           subject.failure(vocabulary)
         end
-        allow(vocabulary).to receive(:id).and_return("1")
-        allow(vocabulary).to receive(:persisted?).and_return(true)
+        result
       end
       it "render new" do
-        result
         expect(response).to render_template "new"
       end
       it "assigns @vocabulary" do
-        result
         expect(assigns(:vocabulary)).to eq vocabulary
       end
     end

--- a/spec/lib/active_triples_adapter_spec.rb
+++ b/spec/lib/active_triples_adapter_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ActiveTriplesAdapter do
     class ExampleResource < ActiveTriples::Resource
       include ActiveTriplesAdapter
       configure :repository => :default
+      configure :type => RDF::URI("http://purl.org/dc/dcam/VocabularyEncodingScheme")
+      configure :base_uri => "http://opaquenamespace.org/ns/"
     end
   end
   after do
@@ -12,6 +14,7 @@ RSpec.describe ActiveTriplesAdapter do
   end
   let(:resource) { ExampleResource.new(uri) }
   let(:uri) { "http://opaquenamespace.org/ns/bla" }
+  let(:id) { "bla" }
   let(:repository) { ActiveTriples::Repositories.repositories[:default] }
   before do
     stub_repository
@@ -31,7 +34,7 @@ RSpec.describe ActiveTriplesAdapter do
         expect(resource).not_to be_persisted
       end
       it "should have no triples" do
-        expect(resource.statements.to_a.length).to eq 0
+        expect(resource.statements.to_a.length).to eq 1
       end
     end
     context "and then triples are persisted" do
@@ -46,7 +49,7 @@ RSpec.describe ActiveTriplesAdapter do
   end
 
   describe "#find" do
-    let(:resource) { ExampleResource.find(uri) }
+    let(:resource) { ExampleResource.find(id) }
     context "when there's nothing in the repository" do
       it "should raise an exception" do
         expect{resource}.to raise_error(ActiveTriples::NotFound)
@@ -66,7 +69,7 @@ RSpec.describe ActiveTriplesAdapter do
   end
   
   describe "#exists?" do
-    let(:result) { ExampleResource.exists?(uri) }
+    let(:result) { ExampleResource.exists?(id) }
     context "when there's nothing in the repository" do
       it "should return false" do
         expect(result).to eq false

--- a/spec/lib/active_triples_adapter_spec.rb
+++ b/spec/lib/active_triples_adapter_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe ActiveTriplesAdapter do
+  before do
+    class ExampleResource < ActiveTriples::Resource
+      include ActiveTriplesAdapter
+      configure :repository => :default
+    end
+  end
+  after do
+    Object.send(:remove_const, "ExampleResource")
+  end
+  let(:resource) { ExampleResource.new(uri) }
+  let(:uri) { "http://opaquenamespace.org/ns/bla" }
+  let(:repository) { ActiveTriples::Repositories.repositories[:default] }
+  before do
+    stub_repository
+  end
+  
+  describe "#new" do
+    context "when there's nothing in the repository" do
+      it "should not be persisted" do
+        expect(resource).not_to be_persisted
+      end
+    end
+    context "when there's something in the repository" do
+      before do
+        repository << RDF::Statement.new(RDF::URI(uri), RDF::DC.title, "bla")
+      end
+      it "should not be persisted" do
+        expect(resource).not_to be_persisted
+      end
+      it "should have no triples" do
+        expect(resource.statements.to_a.length).to eq 0
+      end
+    end
+    context "and then triples are persisted" do
+      before do
+        resource << RDF::Statement.new(RDF::URI(uri), RDF::DC.title, "bla")
+        resource.persist!
+      end
+      it "should be persisted" do
+        expect(resource).to be_persisted
+      end
+    end
+  end
+
+  describe "#find" do
+    let(:resource) { ExampleResource.find(uri) }
+    context "when there's nothing in the repository" do
+      it "should raise an exception" do
+        expect{resource}.to raise_error(ActiveTriples::NotFound)
+      end
+    end
+    context "when there's something in the repository" do
+      before do
+        repository << RDF::Statement.new(RDF::URI(uri), RDF::DC.title, "bla")
+      end
+      it "should be persisted" do
+        expect(resource).to be_persisted
+      end
+      it "should have statements" do
+        expect(resource.statements.to_a.length).not_to eq 0
+      end
+    end
+  end
+end

--- a/spec/lib/active_triples_adapter_spec.rb
+++ b/spec/lib/active_triples_adapter_spec.rb
@@ -64,4 +64,21 @@ RSpec.describe ActiveTriplesAdapter do
       end
     end
   end
+  
+  describe "#exists?" do
+    let(:result) { ExampleResource.exists?(uri) }
+    context "when there's nothing in the repository" do
+      it "should return false" do
+        expect(result).to eq false
+      end
+    end
+    context "when there's something in the repository" do
+      before do
+        repository << RDF::Statement.new(RDF::URI(uri), RDF::DC.title, "bla")
+      end
+      it "should be true" do
+        expect(result).to eq true
+      end
+    end
+  end
 end

--- a/spec/mocks/term_mock.rb
+++ b/spec/mocks/term_mock.rb
@@ -3,13 +3,13 @@ module GlobalMocks
   let(:term_mock) do
     i = instance_double("Term")
     allow(i).to receive(:persisted?).and_return(false)
-    allow(i).to receive(:id).and_return(RDF::URI("bla"))
+    allow(i).to receive(:id).and_return("bla")
     i
   end
   let(:vocabulary_mock) do
     i = instance_double("Vocabulary")
     allow(i).to receive(:persisted?).and_return(false)
-    allow(i).to receive(:id).and_return(RDF::URI("vocab"))
+    allow(i).to receive(:id).and_return("vocab")
     i
   end
 end

--- a/spec/mocks/term_mock.rb
+++ b/spec/mocks/term_mock.rb
@@ -6,10 +6,5 @@ module GlobalMocks
     allow(i).to receive(:id).and_return("bla")
     i
   end
-  let(:vocabulary_mock) do
-    i = fake(:vocabulary)
-    stub(i).persisted? { false }
-    stub(i).id { "Creator" }
-    i
-  end
+  let(:vocabulary_mock) { fake(:vocabulary) }
 end

--- a/spec/mocks/term_mock.rb
+++ b/spec/mocks/term_mock.rb
@@ -1,0 +1,15 @@
+module GlobalMocks
+  extend RSpec::SharedContext
+  let(:term_mock) do
+    i = instance_double("Term")
+    allow(i).to receive(:persisted?).and_return(false)
+    allow(i).to receive(:id).and_return(RDF::URI("bla"))
+    i
+  end
+  let(:vocabulary_mock) do
+    i = instance_double("Vocabulary")
+    allow(i).to receive(:persisted?).and_return(false)
+    allow(i).to receive(:id).and_return(RDF::URI("vocab"))
+    i
+  end
+end

--- a/spec/mocks/term_mock.rb
+++ b/spec/mocks/term_mock.rb
@@ -7,9 +7,9 @@ module GlobalMocks
     i
   end
   let(:vocabulary_mock) do
-    i = instance_double("Vocabulary")
-    allow(i).to receive(:persisted?).and_return(false)
-    allow(i).to receive(:id).and_return("vocab")
+    i = fake(:vocabulary)
+    stub(i).persisted? { false }
+    stub(i).id { "Creator" }
     i
   end
 end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Term do
       resource.persist!
     end
     it "should be retrievable" do
-      expect(Term.new(uri)).not_to be_empty
+      expect(Term.find(uri)).not_to be_empty
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Term do
         expect(resource.issued.first).to eq Date.today
       end
       context "and then re-persisted" do
-        let(:reloaded) { resource.class.new(resource.rdf_subject) }
+        let(:reloaded) { resource.class.find(resource.rdf_subject) }
         let(:before_issued) { reloaded.issued.first }
         before do
           before_issued

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'vocabulary' # Required because Term gets overriden
 
 RSpec.describe Term do
   verify_contract(:term)

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -72,90 +72,20 @@ RSpec.describe Term do
     end
   end
 
-  describe "#issued" do
-    before do
-      stub_repository
-    end
-    context "when it's new" do
-      it "should be empty" do
-        expect(resource.issued).to be_empty
+  describe "#id" do
+    context "with no id" do
+      let(:resource) { Term.new }
+      it "should be nil" do
+        expect(resource.id).to be_nil
       end
     end
-    context "when persisted" do
+    context "with an id" do
+      let(:resource) { Term.new("bla/bla") }
       before do
         resource.persist!
       end
-      it "should be set" do
-        expect(resource.issued).not_to be_empty
-      end
-      it "should be the current day" do
-        expect(resource.issued.first).to eq Date.today
-      end
-      context "and then re-persisted" do
-        let(:reloaded) { resource.class.find(resource.rdf_subject) }
-        let(:before_issued) { reloaded.issued.first }
-        before do
-          before_issued
-          Timecop.travel(Time.current.tomorrow)
-          reloaded.persist!
-        end
-        it "should not change" do
-          expect(before_issued).to eq reloaded.issued.first
-        end
-      end
-    end
-
-    describe "#modified" do
-      before do
-        stub_repository
-      end
-      context "when it's persisted" do
-        before do
-          resource.persist!
-        end
-        it "should be set" do
-          expect(resource.modified).not_to be_empty
-        end
-        it "should be the current day" do
-          expect(resource.modified.first).to eq Date.today
-        end
-        context "and then re-persisted" do
-          let(:reloaded) { resource.class.new(resource.rdf_subject) }
-          let(:before_modified) { reloaded.modified.first }
-          before do
-            before_modified
-            Timecop.travel(Time.current.tomorrow)
-            reloaded.persist!
-          end
-          it "should change" do
-            expect(before_modified).not_to eq reloaded.modified.first
-            expect(reloaded.modified.first).to eq Date.today
-          end
-        end
-      end
-    end
-
-    describe ".base_uri" do
-      it "should be set to opaquenamespace.org" do
-        expect(resource.class.base_uri).to eq "http://opaquenamespace.org/ns/"
-      end
-    end
-
-    describe "#id" do
-      context "with no id" do
-        let(:resource) { Term.new }
-        it "should be nil" do
-          expect(resource.id).to be_nil
-        end
-      end
-      context "with an id" do
-        let(:resource) { Term.new("bla/bla") }
-        before do
-          resource.persist!
-        end
-        it "should be just the id" do
-          expect(resource.id).to eq "bla/bla"
-        end
+      it "should be just the id" do
+        expect(resource.id).to eq "bla/bla"
       end
     end
   end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe Term do
     end
   end
 
+  describe "#exists?" do
+    let(:result) { Term.exists?("bla") }
+    let(:repository) { ActiveTriples::Repositories.repositories[:default] }
+    context "when it is in the repository" do
+      before do
+        stub_repository
+        repository << RDF::Statement.new(RDF::URI(uri), RDF::DC.title, "bla")
+      end
+      it "should be true" do
+        expect(result).to eq true
+      end
+    end
+  end
+
   describe "#vocabulary?" do
     context "when it is a term" do
       it "should not be a vocabulary" do

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -1,10 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Term do
+  verify_contract(:term)
+  it_behaves_like "a term" do
+    let(:resource_class) { Term }
+  end
   let(:uri) { "http://opaquenamespace.org/ns/bla" }
   let(:resource) { Term.new(uri) }
   it "should be an AT::Resource" do
-    expect(Term < ActiveTriples::Resource).to be true
+    expect(resource.class.ancestors).to include ActiveTriples::Resource
   end
   it "should instantiate" do
     expect{Term.new}.not_to raise_error
@@ -21,6 +25,7 @@ RSpec.describe Term do
       expect(Term.find(uri)).not_to be_empty
     end
   end
+
 
   describe "#exists?" do
     let(:result) { Term.exists?("bla") }

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Vocabulary do
-  after(:suite) do
-    puts "HEY MAN ITS POST SUITE"
-  end
   verify_contract(:vocabulary)
+  it_behaves_like "a term" do
+    let(:resource_class) { Vocabulary }
+  end
   let(:resource) { Vocabulary.new }
   let(:id) { nil }
   # This test validates the issued/modified behavior
@@ -13,85 +13,5 @@ RSpec.describe Vocabulary do
   end
 
   describe "contracts" do
-    let(:resource) { Vocabulary.new("Creator") }
-    context "when given Creator" do
-      it "should have a good rdf_subject" do
-        expect(resource.rdf_subject).to eq RDF::URI.new("http://opaquenamespace.org/ns/Creator")
-      end
-    end
-
-    describe "#id" do
-      it "should return the ID" do
-        expect(resource.id).to eq "Creator"
-      end
-    end
-
-    describe "#persist!" do
-      before do
-        stub_repository
-      end
-      context "when verify is true" do
-        context "when there are no errors" do
-          it "should return true" do
-            expect(resource.persist!(:validate => true)).to eq true
-          end
-        end
-      end
-    end
-
-    describe "#attributes=" do
-      context "when attributes are passed" do
-        let(:params) do
-          {
-            :label => ["Test Label"],
-            :comment => ["Test Comment"]
-          }
-        end
-        before do
-          resource.attributes = params
-        end
-        it "should set them" do
-          expect(resource.label).to eq params[:label]
-          expect(resource.comment).to eq params[:comment]
-        end
-      end
-    end
-
-    describe "#add_error" do
-      let(:error_double) { fake(:errors) { ActiveModel::Errors } }
-      before do
-        stub(resource).errors { error_double }
-        resource.add_error(:id, "test")
-      end
-      it "should call #add on errors" do
-        expect(error_double).to have_received.add(:id, "test")
-      end
-    end
-
-    describe "#empty_errors?" do
-      let(:error_double) { fake(:errors) { ActiveModel::Errors } }
-      before do
-        stub(resource).errors { error_double }
-        stub(error_double).empty? { false }
-      end
-      it "should delegate to error_double" do
-        expect(resource.empty_errors?).to eq false
-        expect(error_double).to have_received(:empty?)
-      end
-    end
-
-    describe "#errors" do
-      it "should be ActiveModel::Errors" do
-        expect(resource.errors).to be_kind_of ActiveModel::Errors
-      end
-    end
-
-    describe "#persisted?" do
-      context "when there are no triples" do
-        it "should not be persisted" do
-          expect(resource).not_to be_persisted
-        end
-      end
-    end
   end
 end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -1,21 +1,96 @@
 require 'rails_helper'
 
 RSpec.describe Vocabulary do
+  after(:suite) do
+    puts "HEY MAN ITS POST SUITE"
+  end
+  verify_contract(:vocabulary)
   let(:resource) { Vocabulary.new }
   let(:id) { nil }
   # This test validates the issued/modified behavior
-  it "should be a subclass of Term" do
-    expect(Vocabulary < Term).to be true
-  end
   it "should have a configured type" do
     expect(resource.type).to eq [RDF::URI("http://purl.org/dc/dcam/VocabularyEncodingScheme")]
   end
 
   describe "contracts" do
+    let(:resource) { Vocabulary.new("Creator") }
     context "when given Creator" do
-      let(:resource) { Vocabulary.new("Creator") }
       it "should have a good rdf_subject" do
         expect(resource.rdf_subject).to eq RDF::URI.new("http://opaquenamespace.org/ns/Creator")
+      end
+    end
+
+    describe "#id" do
+      it "should return the ID" do
+        expect(resource.id).to eq "Creator"
+      end
+    end
+
+    describe "#persist!" do
+      before do
+        stub_repository
+      end
+      context "when verify is true" do
+        context "when there are no errors" do
+          it "should return true" do
+            expect(resource.persist!(:validate => true)).to eq true
+          end
+        end
+      end
+    end
+
+    describe "#attributes=" do
+      context "when attributes are passed" do
+        let(:params) do
+          {
+            :label => ["Test Label"],
+            :comment => ["Test Comment"]
+          }
+        end
+        before do
+          resource.attributes = params
+        end
+        it "should set them" do
+          expect(resource.label).to eq params[:label]
+          expect(resource.comment).to eq params[:comment]
+        end
+      end
+    end
+
+    describe "#add_error" do
+      let(:error_double) { fake(:errors) { ActiveModel::Errors } }
+      before do
+        stub(resource).errors { error_double }
+        resource.add_error(:id, "test")
+      end
+      it "should call #add on errors" do
+        expect(error_double).to have_received.add(:id, "test")
+      end
+    end
+
+    describe "#empty_errors?" do
+      let(:error_double) { fake(:errors) { ActiveModel::Errors } }
+      before do
+        stub(resource).errors { error_double }
+        stub(error_double).empty? { false }
+      end
+      it "should delegate to error_double" do
+        expect(resource.empty_errors?).to eq false
+        expect(error_double).to have_received(:empty?)
+      end
+    end
+
+    describe "#errors" do
+      it "should be ActiveModel::Errors" do
+        expect(resource.errors).to be_kind_of ActiveModel::Errors
+      end
+    end
+
+    describe "#persisted?" do
+      context "when there are no triples" do
+        it "should not be persisted" do
+          expect(resource).not_to be_persisted
+        end
       end
     end
   end

--- a/spec/models/vocabulary_spec.rb
+++ b/spec/models/vocabulary_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe Vocabulary do
   it "should have a configured type" do
     expect(resource.type).to eq [RDF::URI("http://purl.org/dc/dcam/VocabularyEncodingScheme")]
   end
+
+  describe "contracts" do
+    context "when given Creator" do
+      let(:resource) { Vocabulary.new("Creator") }
+      it "should have a good rdf_subject" do
+        expect(resource.rdf_subject).to eq RDF::URI.new("http://opaquenamespace.org/ns/Creator")
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ require 'capybara/poltergeist'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
+Dir[Rails.root.join("spec/mocks/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Checks for pending migrations before tests are run.

--- a/spec/routing/term_routes_spec.rb
+++ b/spec/routing/term_routes_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "routes for Terms" do
       let(:id) {"bla/bla"}
       let(:resource) do
         r = klass.new
-        allow(r).to receive(:id).and_return(id)
-        allow(r).to receive(:persisted?).and_return(true)
+        stub(r).id { id }
+        stub(r).persisted? { true }
         r
       end
       it "should route to its id preserving slashes" do

--- a/spec/services/term_creator_spec.rb
+++ b/spec/services/term_creator_spec.rb
@@ -12,13 +12,15 @@ RSpec.describe TermCreator do
   let(:id) { "testing" }
   let(:vocabulary) { vocabulary_mock }
   let(:vocabulary_persisted) { true }
-  let(:callback) { instance_double("TermsController") }
+  let(:callback) { instance_double("TermsController::CreateResponder") }
   let(:term) { term_mock }
   let(:term_valid) { true }
   let(:errors) { instance_double("ActiveModel::Errors") }
   let(:error_empty) { true } 
   before do
     allow(Term).to receive(:new).with("#{vocabulary.id}/#{id}").and_return(term)
+    allow(term).to receive(:id).and_return("#{vocabulary.id}/#{id}")
+    allow(Term).to receive(:exists?).with("#{vocabulary.id}/#{id}").and_return(false)
     allow(vocabulary).to receive(:persisted?).and_return(vocabulary_persisted)
     allow(term).to receive(:errors).and_return(errors)
     allow(term).to receive(:valid?).and_return(term_valid)
@@ -87,7 +89,7 @@ RSpec.describe TermCreator do
     end
     context "when the term IS persisted already" do
       before do
-        allow(Term).to receive(:exists?).with(id).and_return(true)
+        allow(Term).to receive(:exists?).with(term.id).and_return(true)
       end
       it "adds errors to the term" do
         expect(errors).to receive(:add).with(:id, anything)

--- a/spec/services/term_creator_spec.rb
+++ b/spec/services/term_creator_spec.rb
@@ -5,95 +5,85 @@ RSpec.describe TermCreator do
   let(:params) do
     {
       :id => id,
-      :creator => ["Creator"],
-      :label => ["Label"]
+      :label => ["Test Label"],
+      :comment => ["Test Comment"]
     }
   end
   let(:id) { "testing" }
-  let(:vocabulary) { vocabulary_mock }
-  let(:vocabulary_persisted) { true }
-  let(:callback) { instance_double("TermsController::CreateResponder") }
-  let(:term) { term_mock }
+  fake(:vocabulary)
+  let(:callback) { fake(:term_callback) }
+  fake(:term)
+  let(:vocabulary_exists) { true }
   let(:term_valid) { true }
-  let(:errors) { instance_double("ActiveModel::Errors") }
-  let(:error_empty) { true } 
+  let(:term_id) { "#{vocabulary.id}/#{id}".gsub(/\/$/,'') }
+  let(:error_empty) { true }
   before do
-    allow(Term).to receive(:new).with("#{vocabulary.id}/#{id}").and_return(term)
-    allow(term).to receive(:id).and_return("#{vocabulary.id}/#{id}")
-    allow(Term).to receive(:exists?).with("#{vocabulary.id}/#{id}").and_return(false)
-    allow(vocabulary).to receive(:persisted?).and_return(vocabulary_persisted)
-    allow(term).to receive(:errors).and_return(errors)
-    allow(term).to receive(:valid?).and_return(term_valid)
-    allow(term).to receive(:attributes=)
-    allow(errors).to receive(:empty?).and_return(error_empty)
+    stub(Term).new(term_id) { term }
+    stub(Term).new(term_id+"/") { term }
+    stub(term).id { term_id }
+    stub(Term).exists?(term_id) { false }
+    stub(vocabulary).persisted? { vocabulary_exists }
+    stub(term).valid?{term_valid}
+    stub(term).empty_errors? { error_empty }
   end
 
   describe "#call" do
     subject { TermCreator.call(params, vocabulary, callback) }
+    fake(:term_creator)
+    before do
+      stub(TermCreator).new(params, vocabulary, callback) { term_creator }
+    end
     it "should initialize and call perform" do
-      i = instance_double("TermCreator")
-      expect(TermCreator).to receive(:new).with(params, vocabulary, callback).and_return(i)
-      expect(i).to receive(:perform)
       subject
+      expect(term_creator).to have_received.perform
     end
   end
 
   describe "#perform" do
+    before do
+      subject.perform
+    end
     context "when given valid parameters" do
-      before do
-        allow(callback).to receive(:success).with(term, vocabulary)
-        allow(term).to receive(:persist!)
-      end
       it "should call success on callback" do
-        expect(callback).to receive(:success).with(term, vocabulary)
-        subject.perform
+        expect(callback).to have_received.success(term, vocabulary)
       end
       it "should set attributes" do
-        expect(term).to receive(:attributes=).with(params.except(:id))
-        subject.perform
+        expect(term).to have_received(:attributes=, params.except(:id))
       end
       it "should persist the term" do
-        expect(term).to receive(:persist!).with(:validate => true)
-        subject.perform
+        expect(term).to have_received.persist!(:validate => true)
       end
     end
-    end
-  context "when something has gone wrong" do
-    let(:error_empty) { false }
-    before do
-      allow(callback).to receive(:failure).with(term, vocabulary)
-    end
-    context "when term has errors" do
-      it "should call failure on callback" do
-        expect(callback).to receive(:failure).with(term, vocabulary)
-        subject.perform
+    context "when something has gone wrong" do
+      let(:error_empty) { false }
+      context "when term has errors" do
+        it "should call failure on callback" do
+          expect(callback).to have_received.failure(term, vocabulary)
+        end
+        it "should not call persist!" do
+          expect(term).not_to have_received(:persist!)
+        end
       end
-      it "should not call persist!" do
-        expect(term).not_to receive(:persist!)
-        subject.perform
+      context "when term id is nil" do
+        let(:id) { nil }
+        it "adds errors to the term" do
+          expect(term).to have_received.add_error(:id, anything)
+        end
       end
-    end
-    context "when term id is nil" do
-      let(:id) { nil }
-      it "adds errors to the term" do
-        expect(errors).to receive(:add).with(:id, anything)
-        subject.perform
+      context "when the vocabulary is not persisted" do
+        let(:vocabulary_exists) { false }
+        it "adds errors to the term" do
+          expect(term).to have_received.add_error(:id, anything)
+        end
       end
-    end
-    context "when the vocabulary is not persisted" do
-      let(:vocabulary_persisted) { false }
-      it "adds errors to the term" do
-        expect(errors).to receive(:add).with(:id, anything)
-        subject.perform
-      end
-    end
-    context "when the term IS persisted already" do
-      before do
-        allow(Term).to receive(:exists?).with(term.id).and_return(true)
-      end
-      it "adds errors to the term" do
-        expect(errors).to receive(:add).with(:id, anything)
-        subject.perform
+      context "when the term IS persisted already" do
+        before do
+          stub(Term).exists?(term.id) { true }
+          subject.perform
+        end
+        it "adds errors to the term" do
+          expect(term).to have_received.add_error(:id, anything)
+        end
       end
     end
   end

--- a/spec/services/term_creator_spec.rb
+++ b/spec/services/term_creator_spec.rb
@@ -10,24 +10,16 @@ RSpec.describe TermCreator do
     }
   end
   let(:id) { "testing" }
-  let(:vocabulary) { instance_double("Vocabulary") }
-  let(:vocabulary) do
-    v = instance_double("Vocabulary")
-    allow(v).to receive(:id).and_return(vocabulary_id)
-    v
-  end
-  let(:vocabulary_id) { "bla/bla" }
+  let(:vocabulary) { vocabulary_mock }
   let(:vocabulary_persisted) { true }
-  let(:callback) { double("callback") }
-  let(:term) { instance_double("Term") }
-  let(:term_persisted) { false }
+  let(:callback) { instance_double("TermsController") }
+  let(:term) { term_mock }
   let(:term_valid) { true }
-  let(:errors) { double("errors") }
+  let(:errors) { instance_double("ActiveModel::Errors") }
   let(:error_empty) { true } 
   before do
-    allow(Term).to receive(:new).with("#{vocabulary_id}/#{id}").and_return(term)
+    allow(Term).to receive(:new).with("#{vocabulary.id}/#{id}").and_return(term)
     allow(vocabulary).to receive(:persisted?).and_return(vocabulary_persisted)
-    allow(term).to receive(:persisted?).and_return(term_persisted)
     allow(term).to receive(:errors).and_return(errors)
     allow(term).to receive(:valid?).and_return(term_valid)
     allow(term).to receive(:attributes=)
@@ -94,7 +86,9 @@ RSpec.describe TermCreator do
       end
     end
     context "when the term IS persisted already" do
-      let(:term_persisted) { true }
+      before do
+        allow(Term).to receive(:exists?).with(id).and_return(true)
+      end
       it "adds errors to the term" do
         expect(errors).to receive(:add).with(:id, anything)
         subject.perform

--- a/spec/services/vocabulary_creator_spec.rb
+++ b/spec/services/vocabulary_creator_spec.rb
@@ -3,83 +3,67 @@ require 'rails_helper'
 RSpec.describe VocabularyCreator do
   let(:params) do
     {
-      :id => id,
+      :id => vocabulary.id,
       :label => label,
       :comment => comment
     }
   end
-  let(:id) { "Creator" }
   let(:label) { ["Test Label"] }
   let(:comment) { ["Test Comment"] }
-  let(:callback) { double("callback") }
+  let(:callback) { fake(:callback) { VocabulariesController::CreateResponder  }}
   let(:vocabulary) { vocabulary_mock }
   let(:persist_success) { true }
-  let(:error_double) { double("errors") }
   subject { VocabularyCreator.call(params, callback) }
   before do
     stub_repository
-    allow(class_double("Vocabulary").as_stubbed_const).to receive(:new).and_return(vocabulary)
-    allow(vocabulary).to receive(:errors).and_return(error_double)
-    allow(Vocabulary).to receive(:exists?).and_return(false)
-    allow(vocabulary).to receive(:persist!).and_return(persist_success)
-    allow(vocabulary).to receive(:attributes=)
-    allow(vocabulary).to receive(:id).and_return(id)
-    allow(error_double).to receive(:empty?).and_return(true)
+    stub(Vocabulary).new(vocabulary.id) {vocabulary}
+    stub(vocabulary).add_error(anything, anything)
+    stub(Vocabulary).exists?(vocabulary.id) { false }
+    stub(vocabulary).persist!(:validate => true) { persist_success }
   end
 
   describe ".call" do
     let(:result) { subject }
     context "when given good parameters" do
       before do
-        allow(callback).to receive(:success)
+        subject
       end
       it "should call #success on the callback" do
-        expect(callback).to receive(:success).with(vocabulary)
-        subject
+        expect(callback).to have_received.success(vocabulary)
       end
       it "should instantiate a vocab with an ID" do
-        expect(Vocabulary).to receive(:new).with(id)
-        subject
+        expect(Vocabulary).to have_received.new(vocabulary.id)
       end
       it "should set attributes" do
-        expect(vocabulary).to receive(:attributes=).with(params.except(:id))
-        subject
+        expect(vocabulary).to have_received(:attributes=, params.except(:id))
       end
       it "should persist" do
-        expect(vocabulary).to receive(:persist!)
-        subject
+        expect(vocabulary).to have_received.persist!({:validate => true})
       end
     end
     context "when given an already existing vocabulary" do
       before do
-        allow(Vocabulary).to receive(:exists?).with(id).and_return(true)
-        allow(error_double).to receive(:add)
-        allow(error_double).to receive(:empty?).and_return(false)
-        allow(callback).to receive(:failure)
+        stub(Vocabulary).exists?(vocabulary.id) { true }
+        stub(vocabulary).empty_errors? { false }
+        subject
       end
       it "should have errors" do
-        allow(vocabulary).to receive(:errors).and_return(error_double)
-        expect(error_double).to receive(:add)
-        expect(error_double).to receive(:empty?).and_return(false)
-        subject
+        expect(vocabulary).to have_received.add_error(anything, anything)
       end
       it "should notify callbacks of failure" do
-        expect(callback).to receive(:failure).with(vocabulary)
-        subject
+        expect(callback).to have_received.failure(vocabulary)
       end
     end
     context "when given bad parameters" do
       before do
-        expect(error_double).to receive(:empty?).and_return(false)
-        allow(callback).to receive(:failure)
+        stub(vocabulary).empty_errors? { false }
+        subject
       end
       it "should not be persisted" do
-        expect(vocabulary).not_to receive(:persist!)
-        subject
+        expect(vocabulary).not_to have_received.persist!({:validate => true})
       end
       it "should notify callbacks of failure" do
-        expect(callback).to receive(:failure).with(vocabulary)
-        subject
+        expect(callback).to have_received.failure(vocabulary)
       end
     end
   end

--- a/spec/services/vocabulary_creator_spec.rb
+++ b/spec/services/vocabulary_creator_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe VocabularyCreator do
   end
   let(:label) { ["Test Label"] }
   let(:comment) { ["Test Comment"] }
-  let(:callback) { fake(:callback) { VocabulariesController::CreateResponder  }}
-  let(:vocabulary) { vocabulary_mock }
+  fake(:callback)
+  fake(:vocabulary)
   let(:persist_success) { true }
   subject { VocabularyCreator.call(params, callback) }
   before do

--- a/spec/services/vocabulary_creator_spec.rb
+++ b/spec/services/vocabulary_creator_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe VocabularyCreator do
   let(:label) { ["Test Label"] }
   let(:comment) { ["Test Comment"] }
   let(:callback) { double("callback") }
-  let(:vocabulary) { instance_double("Vocabulary") }
-  let(:persisted) { false }
+  let(:vocabulary) { vocabulary_mock }
   let(:persist_success) { true }
   let(:error_double) { double("errors") }
   subject { VocabularyCreator.call(params, callback) }
   before do
     stub_repository
     allow(class_double("Vocabulary").as_stubbed_const).to receive(:new).and_return(vocabulary)
-    allow(vocabulary).to receive(:persisted?).and_return(persisted)
     allow(vocabulary).to receive(:errors).and_return(error_double)
+    allow(Vocabulary).to receive(:exists?).and_return(false)
     allow(vocabulary).to receive(:persist!).and_return(persist_success)
     allow(vocabulary).to receive(:attributes=)
+    allow(vocabulary).to receive(:id).and_return(id)
     allow(error_double).to receive(:empty?).and_return(true)
   end
 
@@ -51,8 +51,8 @@ RSpec.describe VocabularyCreator do
       end
     end
     context "when given an already existing vocabulary" do
-      let(:persisted) { true }
       before do
+        allow(Vocabulary).to receive(:exists?).with(id).and_return(true)
         allow(error_double).to receive(:add)
         allow(error_double).to receive(:empty?).and_return(false)
         allow(callback).to receive(:failure)

--- a/spec/support/bogus.rb
+++ b/spec/support/bogus.rb
@@ -1,0 +1,1 @@
+require 'bogus/rspec'

--- a/spec/support/bogus.rb
+++ b/spec/support/bogus.rb
@@ -1,1 +1,13 @@
 require 'bogus/rspec'
+Bogus.fakes do
+  fake(:vocabulary) do
+    id { "Creator" }
+    persisted? false
+  end
+  fake(:term) do
+    id { "bla" }
+    persisted? true
+  end
+  fake(:callback, :class => proc{VocabulariesController::CreateResponder})
+  fake(:term_callback, :class => proc{TermsController::CreateResponder})
+end

--- a/spec/support/global_mocks.rb
+++ b/spec/support/global_mocks.rb
@@ -1,0 +1,1 @@
+RSpec.configure { |c| c.include GlobalMocks }

--- a/spec/support/shared_examples/term_shared.rb
+++ b/spec/support/shared_examples/term_shared.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.shared_examples "a term" do
+  let(:resource) { resource_class.new(id) }
+  let(:id) { "Creator" }
+  context "when given Creator" do
+    it "should have a good rdf_subject" do
+      expect(resource.rdf_subject).to eq RDF::URI.new("http://opaquenamespace.org/ns/Creator")
+    end
+  end
+
+  describe "#id" do
+    %w{Creator bla}.each do |example_value|
+      let(:id) { example_value }
+      it "should return the ID" do
+        expect(resource.id).to eq id
+      end
+    end
+    context "with a trailing slash" do
+      let(:id) { "Creator/" }
+      it "should not use it" do
+        expect(resource.id).to eq "Creator"
+      end
+      it "should not mess with #rdf_subject" do
+        expect(resource.rdf_subject.to_s).to eq "http://opaquenamespace.org/ns/Creator"
+      end
+    end
+    context "with a deep ID" do
+      let(:id) { "Creator/testing" }
+      it "should return it" do
+        expect(resource.id).to eq id
+      end
+    end
+  end
+
+  describe "#valid?" do
+    context "when no errors" do
+      it "should be valid" do
+        expect(resource).to be_valid
+      end
+    end
+  end
+
+  it "should have empty errors" do
+    expect(resource.empty_errors?).to eq true
+  end
+
+  context "when errors are added" do
+    before do
+      resource.add_error(:id, "test")
+    end
+    it "should not be empty" do
+      expect(resource.empty_errors?).not_to eq true
+    end
+  end
+
+  describe "#persisted?" do
+    let(:repository) { ActiveTriples::Repositories.repositories[:default] }
+    context "when it's in the repository" do
+      before do
+        stub_repository
+        repository << RDF::Statement.new(RDF::URI(resource.rdf_subject.to_s), RDF::DC.title, "bla")
+      end
+      context "and it's persisted" do
+        before do
+          resource.persist!
+        end
+        it "should be persisted" do
+          expect(resource).to be_persisted
+        end
+      end
+    end
+  end
+
+  describe "#persist!" do
+    before do
+      stub_repository
+    end
+    context "when verify is true" do
+      context "when there are no errors" do
+        it "should return true" do
+          expect(resource.persist!(:validate => true)).to eq true
+        end
+      end
+    end
+  end
+
+  describe "#attributes=" do
+    context "when attributes are passed" do
+      let(:params) do
+        {
+          :label => ["Test Label"],
+          :comment => ["Test Comment"]
+        }
+      end
+      before do
+        resource.attributes = params
+      end
+      it "should set them" do
+        expect(resource.label).to eq params[:label]
+        expect(resource.comment).to eq params[:comment]
+      end
+    end
+  end
+
+  describe "#add_error" do
+    let(:error_double) { fake(:errors) { ActiveModel::Errors } }
+    before do
+      stub(resource).errors { error_double }
+      resource.add_error(:id, "test")
+    end
+    it "should call #add on errors" do
+      expect(error_double).to have_received.add(:id, "test")
+    end
+  end
+
+  describe "#valid" do
+    context "when nothing is wrong" do
+      it "should be valid" do
+        expect(resource).to be_valid
+      end
+    end
+  end
+
+  describe "#errors" do
+    it "should be ActiveModel::Errors" do
+      expect(resource.errors).to be_kind_of ActiveModel::Errors
+    end
+  end
+
+  describe "#persisted?" do
+    context "when there are no triples" do
+      it "should not be persisted" do
+        expect(resource).not_to be_persisted
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/term_shared.rb
+++ b/spec/support/shared_examples/term_shared.rb
@@ -33,6 +33,24 @@ RSpec.shared_examples "a term" do
     end
   end
 
+  describe "#dump" do
+    before do
+      resource << RDF::Statement.new(resource.rdf_subject, RDF::DC.creator, "bla")
+    end
+    describe ":ntriples" do
+      let(:result) { resource.dump(:ntriples).split("\n").last }
+      it "should have creator" do
+        expect(result).to eq "<http://opaquenamespace.org/ns/Creator> <http://purl.org/dc/terms/creator> \"bla\" ."
+      end
+    end
+    describe ":jsonld" do
+      let(:result) { JSON.parse(resource.dump(:jsonld, {:standard_prefixes => true})) }
+      it "should work" do
+        expect(result["dc:creator"]).to eq "bla"
+      end
+    end
+  end
+
   describe "#valid?" do
     context "when no errors" do
       it "should be valid" do

--- a/spec/support/shared_examples/term_shared.rb
+++ b/spec/support/shared_examples/term_shared.rb
@@ -153,4 +153,83 @@ RSpec.shared_examples "a term" do
       end
     end
   end
+
+  describe "#issued" do
+    before do
+      Timecop.travel(Time.new(2012,1,1))
+      stub_repository
+    end
+    context "when it's new" do
+      it "should be empty" do
+        expect(resource.issued).to be_empty
+      end
+    end
+    context "when persisted" do
+      before do
+        resource.persist!
+      end
+      it "should be set" do
+        expect(resource.issued).not_to be_empty
+      end
+      it "should be the current day" do
+        expect(resource.issued).to eq [Date.new(2012,1,1)]
+      end
+      context "and then re-persisted" do
+        let(:reloaded) { resource.class.find(resource.rdf_subject) }
+        let(:before_issued) { reloaded.issued}
+        before do
+          before_issued
+          Timecop.travel(Time.new(2012,1,2))
+          reloaded.persist!
+        end
+        it "should not change" do
+          expect(before_issued).to eq reloaded.issued
+        end
+      end
+    end
+
+    describe ".base_uri" do
+      it "should be set to opaquenamespace.org" do
+        expect(resource.class.base_uri).to eq "http://opaquenamespace.org/ns/"
+      end
+    end
+
+    describe "#base_uri" do
+      it "should be set to opaquenamespace.org" do
+        expect(resource.base_uri).to eq "http://opaquenamespace.org/ns/"
+      end
+    end
+
+
+    describe "#modified" do
+      before do
+        Timecop.travel(Time.new(2012,1,1))
+        stub_repository
+      end
+      context "when it's persisted" do
+        before do
+          resource.persist!
+        end
+        it "should be set" do
+          expect(resource.modified).not_to be_empty
+        end
+        it "should be the current day" do
+          expect(resource.modified).to eq [Date.new(2012,1,1)]
+        end
+        context "and then re-persisted" do
+          let(:reloaded) { resource.class.new(resource.rdf_subject) }
+          let(:before_modified) { reloaded.modified.first }
+          before do
+            before_modified
+            Timecop.travel(Time.new(2012,1,2))
+            resource.persist!
+          end
+          it "should change" do
+            expect(before_modified).not_to eq resource.modified.first
+            expect(resource.modified).to eq [Date.new(2012,1,2)]
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/support/stub_controller_auth.rb
+++ b/spec/support/stub_controller_auth.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
   config.before(:type => :controller) do
-    allow(controller).to receive(:authorize).and_return(true)
-    allow(controller).to receive(:authenticate).and_return(true)
+    stub(controller).authorize { true }
+    stub(controller).authenticate { true }
   end
 end

--- a/spec/support/stub_repository.rb
+++ b/spec/support/stub_repository.rb
@@ -1,7 +1,3 @@
 def stub_repository
-  stub(ActiveTriples::Repositories).repositories do
-    {
-      :default => RDF::Repository.new
-    }
-  end
+  ActiveTriples::Repositories.add_repository :default, RDF::Repository.new
 end

--- a/spec/support/stub_repository.rb
+++ b/spec/support/stub_repository.rb
@@ -1,3 +1,7 @@
 def stub_repository
-  allow(ActiveTriples::Repositories).to receive(:repositories).and_return({:default => RDF::Repository.new})
+  stub(ActiveTriples::Repositories).repositories do
+    {
+      :default => RDF::Repository.new
+    }
+  end
 end

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "terms/new" do
   end
 
   context "with a term in the namespace" do
-    let(:term) { Term.new("#{id}/Test") }
+    let(:term) { Term.new("#{vocabulary.id}/Test") }
     it "should have a properly populated ID field" do
       expect(rendered).to have_field("ID", :with => "Test")
     end

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "terms/new" do
   let(:term) { Term.new }
   before do
     allow(vocabulary).to receive(:id).and_return(id)
-    allow(vocabulary).to receive(:rdf_subject).and_return("http://opaquenamespace.org/ns/#{id}")
+    allow(vocabulary).to receive(:rdf_subject).and_return(RDF::URI("http://opaquenamespace.org/ns/#{id}"))
     assign(:vocabulary, vocabulary)
     assign(:term, term)
     render

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -32,21 +32,11 @@ RSpec.describe "terms/new" do
   it "should have a create term button" do
     expect(rendered).to have_button("Create Term")
   end
-  # The below tests deals with Terms that may already exist but have errors.
-  context "when term is persisted" do
-    let(:term) do
-      t = Term.new
-      allow(t).to receive(:persisted?).and_return(true)
-      t
-    end
-    it "should have a create term button" do
-      expect(rendered).to have_button("Create Term")
-    end
-    it "should post to /terms" do
-      expect(rendered).to have_selector("form[action='/terms'][method='post']")
-    end
-    it "should not have a _method field" do
-      expect(rendered).not_to have_selector("input[name='_method']")
+
+  context "with a term in the namespace" do
+    let(:term) { Term.new("#{id}/Test") }
+    it "should have a properly populated ID field" do
+      expect(rendered).to have_field("ID", :with => "Test")
     end
   end
 end

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "terms/new" do
   let(:id) { "Creator" }
-  let(:vocabulary) { Vocabulary.new(id) }
+  let(:vocabulary) { vocabulary_mock }
   let(:term) { Term.new }
   before do
+    allow(vocabulary).to receive(:id).and_return(id)
+    allow(vocabulary).to receive(:rdf_subject).and_return("http://opaquenamespace.org/ns/#{id}")
     assign(:vocabulary, vocabulary)
     assign(:term, term)
     render

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe "terms/new" do
-  let(:id) { "Creator" }
-  let(:vocabulary) { vocabulary_mock }
+  fake(:vocabulary)
   let(:term) { Term.new }
   before do
-    allow(vocabulary).to receive(:id).and_return(id)
-    allow(vocabulary).to receive(:rdf_subject).and_return(RDF::URI("http://opaquenamespace.org/ns/#{id}"))
+    stub(vocabulary).rdf_subject { RDF::URI("http://opaquenamespace.org/ns/#{vocabulary.id}") }
     assign(:vocabulary, vocabulary)
     assign(:term, term)
     render
@@ -24,7 +22,7 @@ RSpec.describe "terms/new" do
     expect(rendered).to have_selector("input[name='term[id]']")
   end
   it "should have a vocabulary ID field" do
-    expect(rendered).to have_selector("input[type='hidden'][name='vocabulary_id'][value='#{id}']")
+    expect(rendered).to have_selector("input[type='hidden'][name='vocabulary_id'][value='#{vocabulary.id}']")
   end
   %w{label comment}.each do |attribute|
     it "has inputs for #{attribute}" do

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -1,23 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "terms/show" do
-  let(:uri) { "http://opaquenamespace.org/ns/bla" }
-  let(:resource) { Term.new(uri) }
+  let(:resource) { fake(:term) }
+  let(:base_uri) { Term.base_uri }
 
   before do
     assign(:term, resource)
-    resource.label = "Blah term"
-    resource.comment = "Blah comment"
-    resource.persist!
-    allow(resource).to receive(:modified).and_call_original
-
+    stub(resource).label { ["Blah term"] }
+    stub(resource).comment { ["Blah comment"] }
+    stub(resource).issued { ["2014-01-02"] }
+    stub(resource).modified { ["2014-01-03"] }
+    stub(resource).base_uri { base_uri }
     render
   end
 
   context "when given a vocab" do
-    let(:resource) { Vocabulary.new(uri) }
+    let(:resource) { fake(:vocabulary, :persisted? => true) }
     it "should have a link to create a resource" do
-      expect(rendered).to have_link "Create Term", :href => "/vocabularies/bla/new"
+      expect(rendered).to have_link "Create Term", :href => "/vocabularies/#{resource.id}/new"
     end
   end
 
@@ -28,20 +28,10 @@ RSpec.describe "terms/show" do
   it "displays the full URI" do
     expect(rendered).to have_content("http://opaquenamespace.org/ns/bla") 
   end
-
-  it "displays the label" do
-    expect(rendered).to have_content("Blah term")
+  %w{label comment issued modified}.each do |attribute|
+    it "displays #{attribute}" do
+      expect(rendered).to have_content(resource.send(attribute).first)
+    end
   end
 
-  it "displays a comment" do
-    expect(rendered).to have_content("Blah comment")
-  end
-
-  it "displays the issued date" do
-    expect(rendered).to have_content(Date.today.iso8601)
-  end
-
-  it "displays the modified date" do
-    expect(resource).to have_received(:modified)
-  end
 end

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe "terms/show" do
 
   before do
     assign(:term, resource)
-    stub(resource).label { ["Blah term"] }
-    stub(resource).comment { ["Blah comment"] }
-    stub(resource).issued { ["2014-01-02"] }
-    stub(resource).modified { ["2014-01-03"] }
+    stub(resource).label { ["Test Label"] }
+    stub(resource).comment { ["Test Comment"] }
+    stub(resource).issued { [Date.new(2012,1,1)] }
+    stub(resource).modified { [Date.new(2012,1,2)] }
     stub(resource).base_uri { base_uri }
     render
   end
@@ -28,10 +28,16 @@ RSpec.describe "terms/show" do
   it "displays the full URI" do
     expect(rendered).to have_content("http://opaquenamespace.org/ns/bla") 
   end
-  %w{label comment issued modified}.each do |attribute|
+  %w{label comment}.each do |attribute|
     it "displays #{attribute}" do
       expect(rendered).to have_content(resource.send(attribute).first)
     end
+  end
+  it "displays modified" do
+    expect(rendered).to have_content "2012-01-02"
+  end
+  it "displays issued" do
+    expect(rendered).to have_content "2012-01-01"
   end
 
 end

--- a/spec/views/vocabularies/new.html.erb_spec.rb
+++ b/spec/views/vocabularies/new.html.erb_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe "vocabularies/new" do
   it "posts to /vocabularies" do
     expect(rendered).to have_selector("form[action='/vocabularies'][method='post']")
   end
+  it "has a create vocabulary button" do
+    expect(rendered).to have_button("Create Vocabulary")
+  end
 
   context "when the vocabulary has errors" do
     let(:vocabulary) do
@@ -26,22 +29,6 @@ RSpec.describe "vocabularies/new" do
       expect(rendered).to have_content("Please review the problems below")
       expect(rendered).to have_content("has problems")
       expect(rendered).to have_content("has more problems")
-    end
-    context "and the vocabulary is not a new record" do
-      let(:vocabulary) do
-        v = Vocabulary.new
-        v.errors.add(:id, "has problems")
-        v.errors.add(:label, "has more problems")
-        allow(v).to receive(:persisted?).and_return(true)
-        v
-      end
-      it "should still post to /vocabularies" do
-        expect(rendered).to have_selector("form[action='/vocabularies'][method='post']")
-        expect(rendered).not_to have_selector("input[name='_method'][value='post']")
-      end
-      it "should say create vocabulary" do
-        expect(rendered).to have_button("Create Vocabulary")
-      end
     end
   end
 end


### PR DESCRIPTION
Don't merge without discussion, please.

This uses Bogus instead of RSpec-Mocks. What this does is require that all stubbed methods' return results has a verified contract, much as in [Integration Tests are a Scam](http://vimeo.com/80533536).

This also adds a wrapper around ActiveTriples::Resource so that it doesn't load on #new, but rather on #find. That way it plays nice with everything expecting an AR-like interface.