### PR TITLE
Remove .rspec from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # Ignore bundler config.
 /.bundle
 
+/.rspec
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/rspec-example
+++ b/rspec-example
@@ -1,2 +1,3 @@
+# Copy this to .rspec
 --color
 --require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ begin
   #   - http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://myronmars.to/n/dev-blog/2014/05/notable-changes-in-rspec-3#new__config_option_to_disable_rspeccore_monkey_patching
   config.disable_monkey_patching!
+  config.color = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
Allows devs to individually customize rspec flags - to fail tests
quickly, skip profile data, enable full backtrace, etc.