### PR TITLE
Feature/tombstone vocabularies

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -35,10 +35,6 @@ class TermsController < ApplicationController
     @term = term_form_repository.find(params[:id])
   end
 
-  def deprecate
-    @term = term_form_repository.find(params[:id])
-  end
-
   def update
     edit_term_form = term_form_repository.find(params[:id])
     edit_term_form.attributes = term_params
@@ -48,6 +44,10 @@ class TermsController < ApplicationController
       @term = edit_term_form
       render "edit"
     end
+  end
+
+  def deprecate
+    @term = term_form_repository.find(params[:id])
   end
 
 

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -35,6 +35,10 @@ class TermsController < ApplicationController
     @term = term_form_repository.find(params[:id])
   end
 
+  def deprecate
+    @term = term_form_repository.find(params[:id])
+  end
+
   def update
     edit_term_form = term_form_repository.find(params[:id])
     edit_term_form.attributes = term_params

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -5,6 +5,7 @@ class Term < ActiveTriples::Resource
   configure :repository => :default
   property :label, :predicate => RDF::RDFS.label
   property :comment, :predicate => RDF::RDFS.comment
+  property :is_replaced_by, :predicate => RDF::DC.isReplacedBy
   property :issued, :predicate => RDF::DC.issued
   property :modified, :predicate => RDF::DC.modified
   delegate :vocabulary_id, :leaf, :to => :term_uri, :prefix => true
@@ -25,7 +26,11 @@ class Term < ActiveTriples::Resource
   end
 
   def editable_fields
-    fields - [:issued, :modified]
+    fields - [:issued, :modified, :is_replaced_by]
+  end
+
+  def editable_fields_deprecate
+    fields - [:issued, :modified, :label, :comment]
   end
 
   def to_param

--- a/app/views/terms/_deprecate_form.html.erb
+++ b/app/views/terms/_deprecate_form.html.erb
@@ -1,0 +1,5 @@
+<p><%= term.rdf_subject %></p>
+  <% term.editable_fields_deprecate.each do |attribute| %>
+    <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => term, :attribute => attribute, :form => f} %>
+  <% end %>
+  <%= f.button :submit, "Deprecate" %>

--- a/app/views/terms/deprecate.html.erb
+++ b/app/views/terms/deprecate.html.erb
@@ -1,0 +1,5 @@
+<h1>Deprecate Term</h1>
+
+<%= simple_form_for(@term, :url => update_term_path(:id => @term.id)) do |f| %>
+  <%= render "deprecate_form", :f => f, :term => @term %>
+<% end %>

--- a/app/views/terms/edit.html.erb
+++ b/app/views/terms/edit.html.erb
@@ -6,4 +6,7 @@
 
 <%= simple_form_for(@term, :url => update_term_path(:id => @term.id)) do |f| %>
   <%= render "edit_form", :f => f, :term => @term %>
+
+  <%= link_to "Deprecate", polymorphic_path([@term], :action => 'deprecate'), :class => 'btn btn-default' %>
 <% end %>
+

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -5,7 +5,12 @@
 <h2><%= @term.rdf_subject %></h4>
 
 <% if !@term.get_values(:is_replaced_by).empty? %>
-  <p><span class="label label-warning">Deprecated</span></p>
+  <div class="alert alert-warning">
+    <strong>Deprecated</strong> - 
+      <%= :is_replaced_by.to_s.humanize %>
+      <%= link_to @term.get_values(:is_replaced_by).first, @term.get_values(:is_replaced_by).first %>
+
+  </div>
 <% end %>
  
 <% if @term.vocabulary? %>
@@ -20,11 +25,7 @@
     <dt><%= field.to_s.humanize %>:</dt>
     <% @term.get_values(field).each do |value| %>
       <dd>
-      <% if(field == :is_replaced_by) %>
-        <%= link_to value, value %>
-      <% else %>
-        <%= value %>
-      <% end %>
+      <%= value %>
       </dd>
     <% end %>
   <% end %>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -3,6 +3,11 @@
 <% end %>
 <h1><%= @term.id %></h2>
 <h2><%= @term.rdf_subject %></h4>
+
+<% if !@term.get_values(:is_replaced_by).empty? %>
+  <p><span class="label label-warning">Deprecated</span>
+<% end %>
+ 
 <% if @term.vocabulary? %>
 <%= link_to "Create Term", new_term_path(:vocabulary_id => @term.id),    {:class=>'btn btn-default'} %>
 <% end %>
@@ -14,7 +19,13 @@
   <% @term.fields.each do |field| %>
     <dt><%= field.to_s.humanize %>:</dt>
     <% @term.get_values(field).each do |value| %>
-      <dd><%= value %></dd>
+      <dd>
+      <% if(field == :is_replaced_by) %>
+        <%= link_to value, value %>
+      <% else %>
+        value
+      <% end %>
+      </dd>
     <% end %>
   <% end %>
 </dl>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -5,7 +5,7 @@
 <h2><%= @term.rdf_subject %></h4>
 
 <% if !@term.get_values(:is_replaced_by).empty? %>
-  <p><span class="label label-warning">Deprecated</span>
+  <p><span class="label label-warning">Deprecated</span></p>
 <% end %>
  
 <% if @term.vocabulary? %>
@@ -23,7 +23,7 @@
       <% if(field == :is_replaced_by) %>
         <%= link_to value, value %>
       <% else %>
-        value
+        <%= value %>
       <% end %>
       </dd>
     <% end %>
@@ -33,3 +33,5 @@
 <p><br/><strong>Other Formats:</strong> <%= link_to "N-Triples", request.original_url + '.nt'  %>, <%= link_to "JSON-LD", request.original_url + '.jsonld' %>
 
 <%= render("vocab_children", :vocabulary => @term) if @term.vocabulary? %>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get '/ns/*id', :to => "terms#show", :as => "term"
   patch 'terms/*id', :to => "terms#update", :as => "update_term"
   patch 'vocabularies/*id', :to => "vocabularies#update", :as => "update_vocabulary"
+  patch 'vocabularies/*id', :to => "vocabularies#deprecate", :as => "deprecate_vocabulary"
 
   get '/login'  => 'login#index'
   get '/login/auth' => 'login#doauth'
@@ -17,6 +18,7 @@ Rails.application.routes.draw do
   resources :terms, :only => [:create]
   get 'terms/*id/edit', :to => "terms#edit", :as => "edit_term"
   get 'terms/*id/deprecate', :to => "terms#deprecate", :as => "deprecate_term"
+  
 
   get "/import_rdf", :to => "import_rdf#index", :as => "import_rdf_form"
   post "/import_rdf", :to => "import_rdf#import", :as => "import_rdf"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get '/vocabularies/*vocabulary_id/new', :to => "terms#new", :as => "new_term"
   resources :terms, :only => [:create]
   get 'terms/*id/edit', :to => "terms#edit", :as => "edit_term"
+  get 'terms/*id/deprecate', :to => "terms#deprecate", :as => "deprecate_term"
 
   get "/import_rdf", :to => "import_rdf#index", :as => "import_rdf_form"
   post "/import_rdf", :to => "import_rdf#import", :as => "import_rdf"

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Term do
 
   describe "#editable_fields" do
     it "should return all fields except issued/modified" do
-      expect(resource.editable_fields).to eq resource.fields - [:issued, :modified]
-      expect(resource.editable_fields).not_to include(:issued, :modified)
+      expect(resource.editable_fields).to eq resource.fields - [:issued, :modified, :is_replaced_by]
+      expect(resource.editable_fields).not_to include(:issued, :modified, :is_replaced_by)
     end
   end
 

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Term do
     end
   end
 
+  describe "#editable_fields_deprecate" do
+    it "should return is_replaced_by field" do
+      expect(resource.editable_fields_deprecate).to eq resource.fields - [:issued, :modified, :label, :comment]
+      expect(resource.editable_fields_deprecate).to include(:is_replaced_by)
+    end
+  end
+
   describe "#term_uri" do
     it "should return the parent URI" do
       expect(resource.term_uri.uri).to eq uri

--- a/spec/views/terms/edit.html.erb_spec.rb
+++ b/spec/views/terms/edit.html.erb_spec.rb
@@ -33,4 +33,7 @@ RSpec.describe "terms/edit" do
   it "should have an Update Term button" do
     expect(rendered).to have_button("Update Term")
   end
+  it "should have a Deprecate Term button" do
+    expect(rendered).to have_content("Deprecate")
+  end
 end

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe "terms/show" do
     end
   end
 
+  context "when term is deprecated" do
+    let(:resource) { 
+      t = Term.new(uri) 
+      t.is_replaced_by = "http://opaquenamespace.org/ns/bla2"
+      t
+    }
+    it "should display deprecated alert" do
+      render
+      expect(rendered).to have_content "Deprecated"
+    end
+  end
+
   it "should have a link to edit the term" do
     render
     


### PR DESCRIPTION
This PR supports deprecating single child terms only, I wasn’t sure if deprecating an entire vocabulary (including their child terms) was required. The deprecate form that I am using only shows up in the edit form of an individual term, but I could enable it for the parent vocabulary term as well. 

fixes #38 
fixes #77 