### PR TITLE
Feature/hide create edit

### DIFF
--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -1,10 +1,12 @@
 <h1><%= @term.id %></h2>
 <h2><%= @term.rdf_subject %></h4>
-<% if @term.vocabulary? %>
-<%= link_to "Create Term", new_term_path(:vocabulary_id => @term.id),    {:class=>'btn btn-default'} %>
-<% end %>
-<p><%= link_to "Edit", polymorphic_path([:edit, @term]), {:class=>'btn btn-default'} %>
 
+<%- if session[:authorized] == true  %>
+  <% if @term.vocabulary? %>
+    <%= link_to "Create Term", new_term_path(:vocabulary_id => @term.id),    {:class=>'btn btn-default'} %>
+  <% end %>
+  <p><%= link_to "Edit", polymorphic_path([:edit, @term]), {:class=>'btn btn-default'} %>
+<% end %>
 <br/><%= link_to "Return to Vocabulary", term_path(:id => @term.term_uri_vocabulary_id) unless @term.vocabulary? %></p>
 
 <dl>

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Vocabularies</h1>
-
-<%= link_to "Create Vocabulary", new_vocabulary_path, {:class=>'btn btn-default'} %>
-
+<%- if session[:authorized] == true  %>
+  <%= link_to "Create Vocabulary", new_vocabulary_path, {:class=>'btn btn-default'} %>
+<% end %>
 <ul>
   <% @vocabularies.each do |vocabulary| %>
     <li>

--- a/spec/features/create_term_spec.rb
+++ b/spec/features/create_term_spec.rb
@@ -3,23 +3,15 @@ require 'rails_helper'
 RSpec.feature "Creating a vocabulary & term" do
   background do
     allow_any_instance_of(ApplicationController).to receive(:check_auth).and_return(true)
-    @vocabulary_page = VocabularyIndexPage.new
-    visit vocabularies_path
   end
   scenario "succesfully creating a term" do
-    expect(@vocabulary_page).to be_visible
-    vocabulary_create_page = @vocabulary_page.click_create
-
-    expect(vocabulary_create_page).to be_visible
-    vocabulary_show_page = vocabulary_create_page.create
-
-    expect(vocabulary_show_page).to be_visible
-    term_create_page = vocabulary_show_page.click_create_term
-
-    expect(term_create_page).to be_visible
-    term_show_page = term_create_page.create
-
-    expect(term_show_page).to be_visible
-
+    visit "/vocabularies/new"
+    page.fill_in "vocabulary_id", :with => "pebble"
+    page.click_button "Create Vocabulary"
+    expect(page.body).to include("pebble")
+    visit "/vocabularies/pebble/new"
+    page.fill_in "term_id", :with => "fruity"
+    page.click_button "Create Term"
+    expect(page.body).to include("fruity")
   end
 end

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -21,9 +21,30 @@ RSpec.describe "terms/show" do
       allow(vocabulary).to receive(:persisted?).and_return(true)
       render
     end
-    it "should have a link to create a resource" do
-      expect(rendered).to have_link "Create Term", :href => "/vocabularies/bla/new"
+    context "when logged in" do
+      before do
+        session[:authorized] = true
+      end
+      it "should have a link to create a resource" do
+         render
+         expect(rendered).to have_link "Create Term", :href => "/vocabularies/bla/new"
+      end
+      it "should have a link to edit the vocabulary" do
+        render
+        expect(rendered).to have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+      end
     end
+    context "when not logged in" do
+      it "should not have a link to create a resource" do
+         render
+         expect(rendered).to_not have_link "Create Term", :href => "/vocabularies/bla/new"
+      end
+      it "should not have a link to edit the vocabulary" do
+        render
+        expect(rendered).to_not have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+      end
+    end
+
     context "with children" do
       let(:child) { Term.new(uri.to_s+"/banana") }
       let(:children) { [child] }
@@ -32,15 +53,21 @@ RSpec.describe "terms/show" do
         expect(rendered).to have_link child.rdf_subject.to_s
       end
     end
-    it "should have a link to edit the vocabulary" do
-      expect(rendered).to have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+  end
+  context "when logged in" do
+    before do
+      session[:authorized] = true
+    end
+    it "should have a link to edit the term" do
+      render
+      expect(rendered).to have_link "Edit", :href => edit_term_path(:id => resource.id)
     end
   end
-
-  it "should have a link to edit the term" do
-    render
-    
-    expect(rendered).to have_link "Edit", :href => edit_term_path(:id => resource.id)
+  context "when not logged in" do
+    it "should not have a link to edit the term" do
+      render
+      expect(rendered).to_not have_link "Edit", :href => edit_term_path(:id => resource.id)
+    end
   end
 
   it "should display all fields" do

--- a/spec/views/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/vocabularies/index.html.erb_spec.rb
@@ -10,7 +10,19 @@ RSpec.describe "vocabularies/index.html.erb" do
   it "should display all vocabularies" do
     expect(rendered).to have_link(vocabulary.rdf_subject.to_s, :href => term_path(:id => vocabulary.id))
   end
-  it "should display a link to create a new vocabulary" do
-    expect(rendered).to have_link "Create Vocabulary", :href => "/vocabularies/new"
+  context "when logged in" do
+    before do
+      session[:authorized] = true
+    end
+    it "should display a link to create a new vocabulary" do
+      render
+      expect(rendered).to have_link "Create Vocabulary", :href => "/vocabularies/new"
+    end
+  end
+  context "when not logged in" do
+    it "should not display link to create new vocab" do
+      render
+      expect(rendered).to_not have_link "Create Vocabulary", :href => "/vocabularies/new"
+    end
   end
 end


### PR DESCRIPTION
fixes #79

After doing some searching, realized it's not possible to start the feature spec from the show pages because we use session[:authorized] to hide the create and edit links and there is no access to the session vars. We could install another gem (like https://github.com/railsware/rack_session_access) to get access. But since we test the hide/display functionality in the view tests, I bypassed this part of the end-to-end test.