### PR TITLE
Feature/hide create edit3

### DIFF
--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -13,12 +13,12 @@
 
   </div>
 <% end %>
- 
-<% if @term.vocabulary? %>
-<%= link_to "Create Term", new_term_path(:vocabulary_id => @term.id), {:class=>'btn btn-default'} %>
+<%- if session[:authorized] == true  %>
+  <% if @term.vocabulary? %>
+    <%= link_to "Create Term", new_term_path(:vocabulary_id => @term.id), {:class=>'btn btn-default'} %>
+  <% end %>
+  <%= link_to "Edit", polymorphic_path([:edit, @term]), {:class=>'btn btn-default'} %>
 <% end %>
-
-<%= link_to "Edit", polymorphic_path([:edit, @term]), {:class=>'btn btn-default'} %>
 <%= link_to "Return to Vocabulary", term_path(:id => @term.term_uri_vocabulary_id) unless @term.vocabulary? %>
 
 <table class="table table-condensed" style="margin-top: 20px;">

--- a/app/views/vocabularies/index.html.erb
+++ b/app/views/vocabularies/index.html.erb
@@ -2,9 +2,9 @@
   Vocabularies
 <% end %>
 <h1>Vocabularies</h1>
-
-<%= link_to "Create Vocabulary", new_vocabulary_path, {:class=>'btn btn-default'} %>
-
+<%- if session[:authorized] == true  %>
+  <%= link_to "Create Vocabulary", new_vocabulary_path, {:class=>'btn btn-default'} %>
+<% end %>
 <table class="table table-striped">
   <% @vocabularies.each do |vocab| %>
     <tr>

--- a/spec/features/create_term_spec.rb
+++ b/spec/features/create_term_spec.rb
@@ -3,19 +3,19 @@ require 'rails_helper'
 RSpec.feature "Creating a vocabulary & term", :js => true do
   background do
     allow_any_instance_of(ApplicationController).to receive(:check_auth).and_return(true)
-    @vocabulary_page = VocabularyIndexPage.new
-    visit vocabularies_path
   end
   scenario "succesfully creating a term" do
-    expect(@vocabulary_page).to be_visible
-    vocabulary_create_page = @vocabulary_page.click_create
+    vocabulary_create_page = VocabularyCreatePage.new
+    visit "/vocabularies/new"
 
     expect(vocabulary_create_page).to be_visible
     vocabulary_show_page = vocabulary_create_page.create
     
     expect(get_vocab_statement_list[3].object.language).to eq :aa
     expect(vocabulary_show_page).to be_visible
-    term_create_page = vocabulary_show_page.click_create_term
+
+    term_create_page = TermCreatePage.new("TestVocab")
+    visit "/vocabularies/TestVocab/new"
 
     expect(term_create_page).to be_visible
     term_show_page = term_create_page.create

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -21,8 +21,28 @@ RSpec.describe "terms/show" do
       allow(vocabulary).to receive(:persisted?).and_return(true)
       render
     end
-    it "should have a link to create a resource" do
-      expect(rendered).to have_link "Create Term", :href => "/vocabularies/bla/new"
+    context "when logged in" do
+      before do
+        session[:authorized] = true
+      end
+      it "should have a link to create a resource" do
+         render
+         expect(rendered).to have_link "Create Term", :href => "/vocabularies/bla/new"
+      end
+      it "should have a link to edit the vocabulary" do
+        render
+        expect(rendered).to have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+      end
+    end
+    context "when not logged in" do
+      it "should not have a link to create a resource" do
+         render
+         expect(rendered).to_not have_link "Create Term", :href => "/vocabularies/bla/new"
+      end
+      it "should not have a link to edit the vocabulary" do
+        render
+        expect(rendered).to_not have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+      end
     end
     context "with children" do
       let(:child) { 
@@ -37,10 +57,17 @@ RSpec.describe "terms/show" do
         expect(rendered).to have_content("BananaChild")
       end
     end
-    it "should have a link to edit the vocabulary" do
-      expect(rendered).to have_link "Edit", :href => edit_vocabulary_path(:id => resource.id)
+  end
+  context "when logged in" do
+    before do
+      session[:authorized] = true
+    end
+    it "should have a link to edit the term" do
+      render
+      expect(rendered).to have_link "Edit", :href => edit_term_path(:id => resource.id)
     end
   end
+
 
   context "when term is deprecated" do
     let(:resource) { 
@@ -54,10 +81,11 @@ RSpec.describe "terms/show" do
     end
   end
 
-  it "should have a link to edit the term" do
-    render
-    
-    expect(rendered).to have_link "Edit", :href => edit_term_path(:id => resource.id)
+  context "when not logged in" do
+    it "should not have a link to edit the term" do
+      render
+      expect(rendered).to_not have_link "Edit", :href => edit_term_path(:id => resource.id)
+    end
   end
 
   it "should display all fields" do

--- a/spec/views/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/vocabularies/index.html.erb_spec.rb
@@ -17,7 +17,19 @@ RSpec.describe "vocabularies/index.html.erb" do
   it "should display the label/title of the vocabulary" do
     expect(rendered).to have_content("Test Vocabulary")
   end
-  it "should display a link to create a new vocabulary" do
-    expect(rendered).to have_link "Create Vocabulary", :href => "/vocabularies/new"
+  context "when logged in" do
+    before do
+      session[:authorized] = true
+    end
+    it "should display a link to create a new vocabulary" do
+      render
+      expect(rendered).to have_link "Create Vocabulary", :href => "/vocabularies/new"
+    end
+  end
+  context "when not logged in" do
+    it "should not display link to create new vocab" do
+      render
+      expect(rendered).to_not have_link "Create Vocabulary", :href => "/vocabularies/new"
+    end
   end
 end


### PR DESCRIPTION
fixes #79 
to recap: session vars are not available in feature/specs, so to deal with that, I skipped clicking create and just launched the new vocab and term pages. The hiding/displaying functionality is tested in the view specs.