### PR TITLE
sorts vocabularies#index by vocabulary label alphabetically

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,8 @@ GEM
       net-sftp (>= 2.0.0)
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
-    capybara (2.4.4)
+    capybara (2.6.2)
+      addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -224,9 +225,9 @@ GEM
       sparql-client
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     minitest (5.7.0)
-    multi_json (1.10.1)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     net-http-persistent (2.9.4)
     net-scp (1.2.1)
@@ -237,14 +238,14 @@ GEM
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     netrc (0.7.7)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
     octokit (3.7.0)
       sawyer (~> 0.6.0, >= 0.5.3)
     passenger (5.0.7)
       rack
       rake (>= 0.8.1)
-    poltergeist (1.5.1)
+    poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -272,8 +273,8 @@ GEM
     pry-stack_explorer (0.4.9.1)
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
-    rack (1.5.2)
-    rack-test (0.6.2)
+    rack (1.5.5)
+    rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.7)
       actionmailer (= 4.1.7)
@@ -442,9 +443,9 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    websocket-driver (0.5.0)
+    websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.1)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.6)
@@ -494,3 +495,6 @@ DEPENDENCIES
   warden-github-rails
   warden-rspec-rails!
   webmock
+
+BUNDLED WITH
+   1.11.2

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -4,6 +4,7 @@ class VocabulariesController < ApplicationController
 
   def index
     @vocabularies = all_vocabs_query.call
+    @vocabularies.sort_by! {|v| v[:label]}
   end
 
   def new

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe VocabulariesController do
       allow(vocabulary).to receive(:attributes).and_return(params)
       patch :update, :id => vocabulary.id, :vocabulary => params
     end
-    
+
     context "when the fields are edited" do
       it "should update the properties" do
         expect(vocabulary).to have_received(:attributes=).with(params).exactly(2).times
@@ -97,16 +97,25 @@ RSpec.describe VocabulariesController do
 
   describe "GET 'index'" do
     context "when there are vocabularies" do
-      let(:vocabulary) { vocabulary_mock }
       let(:injector) { VocabularyInjector.new }
+      let(:aa_vocab) {
+        a_v = Vocabulary.new("aa")
+        a_v.label = "AA"
+        a_v
+      }
+      let(:bb_vocab) {
+        b_v = Vocabulary.new("bb")
+        b_v.label = "BB"
+        b_v
+      }
       before do
-        allow(vocabulary).to receive(:repository).and_return(Vocabulary.new.repository)
-        allow(AllVocabsQuery).to receive(:call).and_return([vocabulary])
+        allow(aa_vocab).to receive(:repository).and_return(Vocabulary.new.repository)
+        allow(bb_vocab).to receive(:repository).and_return(Vocabulary.new.repository)
+        allow(AllVocabsQuery).to receive(:call).and_return([bb_vocab, aa_vocab])
       end
-      it "should set @vocabularies to all vocabs" do
+      it "should set @vocabularies to all vocabs sorted alphabetically" do
         get :index
-
-        expect(assigns(:vocabularies)).to eq [vocabulary]
+        expect(assigns(:vocabularies)).to eq [aa_vocab, bb_vocab]
       end
     end
     it "should be successful" do
@@ -144,7 +153,7 @@ RSpec.describe VocabulariesController do
       allow(vocabulary).to receive(:id).and_return("test")
       allow(vocabulary).to receive(:attributes=)
       allow(vocabulary).to receive(:attributes).and_return(vocabulary_params)
-      post 'create', :vocabulary => vocabulary_params 
+      post 'create', :vocabulary => vocabulary_params
     end
     it "should save term form" do
       expect(vocabulary_form).to have_received(:save)

--- a/spec/queries/all_vocabs_query_spec.rb
+++ b/spec/queries/all_vocabs_query_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe AllVocabsQuery do
         vocabulary.persist!
       end
       it "should return all vocabularies" do
-        expect(described_class.call(sparql_client, repository)).to eq [vocabulary]
+        expect(described_class.call(sparql_client, repository)).to include(vocabulary)
       end
       it "should not return terms" do
         repository.new("2/1").persist!
-        expect(described_class.call(sparql_client, repository)).to eq [vocabulary]
+        expect(described_class.call(sparql_client, repository)).to include(vocabulary)
       end
     end
   end

--- a/spec/views/vocabularies/index.html.erb_spec.rb
+++ b/spec/views/vocabularies/index.html.erb_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "vocabularies/index.html.erb" do
   let(:vocabs) { [vocabulary] }
-  let(:vocabulary) { 
-    v = Vocabulary.new("bla") 
+  let(:vocabulary) {
+    v = Vocabulary.new("bla")
     v.label = "Test Vocabulary"
     v
   }


### PR DESCRIPTION
establishes a controller spec to evaluate sortedness, and fixes another spec which has unintended side effects regarding the mock usage for vocabularies. 

phantomjs ver 2+ required an updated version of poltergeist gem

Fixes #157 