### PR TITLE
Rework languages to work with multiples. Extend terms to support language

### DIFF
--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -22,8 +22,8 @@ class TermsController < ApplicationController
     @vocabulary = find_vocabulary
     combined_id = CombinedId.new(params[:vocabulary_id], term_params[:id])
     term_form = term_form_repository.new(combined_id)
-    term_form.attributes = term_params.except(:id)
-    term_form.set_languages(params)
+    term_form.attributes = vocab_params.except(:id)
+    term_form.set_languages(params[:vocabulary])
     if term_form.save
       redirect_to term_path(:id => term_form.id)
     else
@@ -38,8 +38,8 @@ class TermsController < ApplicationController
 
   def update
     edit_term_form = term_form_repository.find(params[:id])
-    edit_term_form.attributes = term_params
-    edit_term_form.set_languages(params)
+    edit_term_form.attributes = vocab_params
+    edit_term_form.set_languages(params[:vocabulary])
     if edit_term_form.save
       redirect_to term_path(:id => params[:id])
     else
@@ -57,6 +57,10 @@ class TermsController < ApplicationController
 
   def term_params
     ParamCleaner.call(params[:term])
+  end
+
+  def vocab_params
+    ParamCleaner.call(params[:vocabulary].except(:language))
   end
 
   def injector

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -60,7 +60,7 @@ class TermsController < ApplicationController
   end
 
   def vocab_params
-    ParamCleaner.call(params[:vocabulary].except(:language))
+    ParamCleaner.call(params[:vocabulary])
   end
 
   def injector

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -29,7 +29,6 @@ class VocabulariesController < ApplicationController
   def update
     edit_vocabulary_form = vocabulary_form_repository.find(params[:id])
     edit_vocabulary_form.attributes = vocabulary_params
-    binding.pry
     edit_vocabulary_form.set_languages(params[:vocabulary])
     if edit_vocabulary_form.save
       redirect_to term_path(:id => params[:id])

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -41,7 +41,7 @@ class VocabulariesController < ApplicationController
   private
 
   def vocabulary_params
-    ParamCleaner.call(params[:vocabulary].except(:language))
+    ParamCleaner.call(params[:vocabulary])
   end
 
   def injector

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -13,7 +13,7 @@ class VocabulariesController < ApplicationController
   def create
     vocabulary_form = vocabulary_form_repository.new(vocabulary_params[:id])
     vocabulary_form.attributes = vocabulary_params.except(:id)
-    vocabulary_form.set_languages(params)
+    vocabulary_form.set_languages(params[:vocabulary])
     if vocabulary_form.save
       redirect_to term_path(:id => vocabulary_form.id)
     else
@@ -29,7 +29,8 @@ class VocabulariesController < ApplicationController
   def update
     edit_vocabulary_form = vocabulary_form_repository.find(params[:id])
     edit_vocabulary_form.attributes = vocabulary_params
-    edit_vocabulary_form.set_languages(params)
+    binding.pry
+    edit_vocabulary_form.set_languages(params[:vocabulary])
     if edit_vocabulary_form.save
       redirect_to term_path(:id => params[:id])
     else
@@ -41,7 +42,7 @@ class VocabulariesController < ApplicationController
   private
 
   def vocabulary_params
-    ParamCleaner.call(params[:vocabulary])
+    ParamCleaner.call(params[:vocabulary].except(:language))
   end
 
   def injector

--- a/app/decorators/sets_attributes.rb
+++ b/app/decorators/sets_attributes.rb
@@ -5,9 +5,9 @@ class SetsAttributes < SimpleDelegator
       unless self.blacklisted_language_properties.include?(key.to_sym) 
         value_array = []
         value.each_with_index do |val, index|
-          value_array << RDF::Literal(val, :language => form_params[:language][key][index])
+          value_array << RDF::Literal(val, :language => form_params[:language][key][index]) unless form_params[:language][key].blank?
         end
-        new_hash[key] = value_array
+        new_hash[key] = value_array unless key == :language
       end
     end
     self.attributes = new_hash

--- a/app/decorators/sets_attributes.rb
+++ b/app/decorators/sets_attributes.rb
@@ -2,10 +2,10 @@ class SetsAttributes < SimpleDelegator
   def set_languages(form_params)
     new_hash = {}
     self.attributes.each_pair do |key, value|
-      unless key == "id" || key == "issued" || key == "modified"
+      unless self.blacklisted_language_properties.include?(key.to_sym) 
         value_array = []
-        value.each do |val|
-          value_array << RDF::Literal(val, :language => form_params[key])
+        value.each_with_index do |val, index|
+          value_array << RDF::Literal(val, :language => form_params[:language][key][index])
         end
         new_hash[key] = value_array
       end

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -21,7 +21,9 @@ class Term < ActiveTriples::Resource
     [
       :id,
       :issued,
-      :modified
+      :modified,
+      :is_defined_by,
+      :is_replaced_by
     ]
   end
 

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -13,6 +13,10 @@ class Term < ActiveTriples::Resource
 
   validate :not_blank_node
 
+  def default_language
+    :en
+  end
+
   def blacklisted_language_properties
     [
       :id,

--- a/app/models/vocabulary.rb
+++ b/app/models/vocabulary.rb
@@ -2,4 +2,5 @@ class Vocabulary < Term
   configure :type => RDF::URI("http://purl.org/dc/dcam/VocabularyEncodingScheme")
   property :title, :predicate => RDF::DC.title
   property :publisher, :predicate => RDF::DC.publisher
+
 end

--- a/app/views/terms/_deprecate_form.html.erb
+++ b/app/views/terms/_deprecate_form.html.erb
@@ -1,5 +1,5 @@
 <p><%= term.rdf_subject %></p>
   <% term.editable_fields_deprecate.each do |attribute| %>
-    <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => term, :attribute => attribute, :form => f} %>
+    <%= render :partial => "vocabularies/form_attribute_list", :locals => {:vocabulary => term, :attribute => attribute, :form => f} %>
   <% end %>
   <%= f.button :submit, "Deprecate" %>

--- a/app/views/terms/_edit_form.html.erb
+++ b/app/views/terms/_edit_form.html.erb
@@ -1,6 +1,6 @@
   <p><%= term.rdf_subject %></p>
 
   <% term.editable_fields.each do |attribute| %>
-    <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => term, :attribute => attribute, :form => f} %>
+    <%= render :partial => "vocabularies/form_attribute_list", :locals => {:vocabulary => term, :attribute => attribute, :form => f} %>
   <% end %>
   <%= f.button :submit %>

--- a/app/views/terms/new.html.erb
+++ b/app/views/terms/new.html.erb
@@ -7,7 +7,7 @@
 <%= simple_form_for(@term, :url => terms_path, :as => :term) do |f| %>
   <%= render "form_id", :f => f %>
   <% @term.editable_fields.each do |attribute| %>
-    <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => @term, :attribute => attribute, :form => f} %>
+    <%= render :partial => "vocabularies/form_attribute_list", :locals => {:vocabulary => @term, :attribute => attribute, :form => f} %>
   <% end %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -7,9 +7,9 @@
 
 <% if !@term.get_values(:is_replaced_by).empty? %>
   <div class="alert alert-warning">
-    <strong>Deprecated</strong> - 
-      <%= :is_replaced_by.to_s.humanize %>
-      <%= link_to @term.get_values(:is_replaced_by).first, @term.get_values(:is_replaced_by).first %>
+    <strong>Deprecated</strong> -
+    <%= :is_replaced_by.to_s.humanize %>
+    <%= link_to @term.get_values(:is_replaced_by).first, @term.get_values(:is_replaced_by).first %>
 
   </div>
 <% end %>
@@ -26,7 +26,17 @@
     <tr>
       <th scope="row"><%= field.to_s.humanize %>:</th>
       <td>
-        <%= @term.get_values(field).join("; ") %>
+        <ul style="list-style: none;">
+          <% if @term.blacklisted_language_properties.include?(field) %>
+            <% @term.get_values(field).each do |t| %>
+              <li><%= t %></li>
+            <% end %>
+          <% else %>
+            <% @term.literal_language_list_for_property(field).each do |t| %>
+              <li><%= "#{t[0].value} (#{t[1]}/#{t[0].language})" %></li>
+            <% end %>
+          <% end %>
+        </ul>
       </td>
     </tr>
   <% end %>

--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -33,7 +33,11 @@
             <% end %>
           <% else %>
             <% @term.literal_language_list_for_property(field).each do |t| %>
-              <li><%= "#{t[0].value} (#{t[1]}/#{t[0].language})" %></li>
+              <% if t[1] == "Language Not Found" %>
+                <li><%= "#{t[0].value}" %> </li>
+              <% else %>
+                <li><%= "#{t[0].value} (#{t[1]}/#{t[0].language})" %></li>
+              <% end %>
             <% end %>
           <% end %>
         </ul>

--- a/app/views/vocabularies/_form.html.erb
+++ b/app/views/vocabularies/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="form-inputs">
     <%= f.input :id, :label => "ID" %>
     <% vocabulary.editable_fields.each do |field| %>
-      <%= render :partial => "form_attribute", :locals => {:vocabulary => vocabulary, :attribute => field, :form => f} %>
+      <%= render :partial => "form_attribute_list", :locals => {:vocabulary => vocabulary, :attribute => field, :form => f} %>
     <% end %>
   </div>
 

--- a/app/views/vocabularies/_form_attribute.html.erb
+++ b/app/views/vocabularies/_form_attribute.html.erb
@@ -1,13 +1,22 @@
 <label class="control-label" for="vocabulary_"><%= attribute.to_s.humanize %></label>
 
-<%= form.input attribute, :wrapper => :vertical_input_group, :as => :array, :label => false do %>
-  <%= form.input_field attribute, :as => :array, :class => "form-control" %>
-  <select name="<%= attribute %>" id="language_selector">
-    <% ISO_639::ISO_639_1.each do |language|%>
-      <option value=<%= language[2] %>><%= language[3]%></option>
+<% form.object.values_for_property(attribute).each_with_index do |value, index| %>
+  <%= form.input attribute, :wrapper => :vertical_input_group, :as => :array, :label => false do %>
+    <%#= form.input_field attribute, :as => :array, :class => "form-control" %>
+    <input type="text" class="form-control" value="<%= value %>" name="<%= "vocabulary[#{attribute.to_s}][]" %>"/>
+    <% unless form.object.blacklisted_language_properties.include?(attribute) %>
+      <select name="<%= "vocabulary[language][#{attribute.to_s}][]" %>" >
+        <% ControlledVocabManager::IsoLanguageTranslator.language_list.each_pair do |symbol, string| %>
+          <% if form.object.literal_language_list_for_property(attribute)[index].first.language == symbol %>
+            <option value=<%= symbol %> selected="selected"><%= string %></option>
+          <% else %>
+            <option value=<%= symbol %>><%= string %></option>
+          <% end %>
+        <% end %>
+      </select>
+    <% end %>
+    <span class="input-group-btn">
+      <button class="btn btn-success" type="button">+</button>
+    </span>
   <% end %>
-  </select>
-  <span class="input-group-btn">
-    <button class="btn btn-success" type="button">+</button>
-  </span>
 <% end %>

--- a/app/views/vocabularies/_form_attribute_list.html.erb
+++ b/app/views/vocabularies/_form_attribute_list.html.erb
@@ -1,0 +1,8 @@
+<label class="control-label" for="vocabulary_"><%= attribute.to_s.humanize %></label>
+<% if form.object.values_for_property(attribute).empty? %>
+  <%= render :partial => "vocabularies/form_attribute", :locals => {:vocabulary => vocabulary, :attribute => attribute, :form => form, :value => ""} %>
+<% else %>
+  <% form.object.values_for_property(attribute).each_with_index do |value, index| %>
+    <%= render :partial => "vocabularies/form_attribute_with_index", :locals => {:vocabulary => vocabulary, :attribute => attribute, :form => form, :value => value, :index => index} %>
+  <% end %>
+<% end %>

--- a/app/views/vocabularies/_form_attribute_with_index.html.erb
+++ b/app/views/vocabularies/_form_attribute_with_index.html.erb
@@ -1,7 +1,7 @@
 <%= form.input attribute, :wrapper => :vertical_input_group, :as => :array, :label => false do %>
   <input type="text" class="form-control" value="<%= value %>" name="<%= "vocabulary[#{attribute.to_s}][]" %>"/>
   <% unless form.object.blacklisted_language_properties.include?(attribute) %>
-    <select name="<%= "vocabulary[language][#{attribute.to_s}][]" %>" >
+    <select name="<%= "vocabulary[language][#{attribute.to_s}][]" %>" id="<%= "#{attribute}_select_#{index}" %>" >
       <% ControlledVocabManager::IsoLanguageTranslator.language_list.each_pair do |symbol, string| %>
         <% if form.object.literal_language_list_for_property(attribute).length > 0 %>
           <option value=<%= symbol %>

--- a/app/views/vocabularies/_language_partial.html.erb
+++ b/app/views/vocabularies/_language_partial.html.erb
@@ -1,5 +1,0 @@
-<select name="<%= attribute %>" id="language_selector">
-<% ISO_639::ISO_639_1.each do |language|%>
-  <option value=<%= language[2] %>><%= language[3]%></option>
-<% end %>
-</select>

--- a/app/views/vocabularies/_language_partial.html.erb
+++ b/app/views/vocabularies/_language_partial.html.erb
@@ -1,0 +1,5 @@
+<select name="<%= attribute %>" id="language_selector">
+<% ISO_639::ISO_639_1.each do |language|%>
+  <option value=<%= language[2] %>><%= language[3]%></option>
+<% end %>
+</select>

--- a/lib/controlled_vocab_manager/iso_language_translator.rb
+++ b/lib/controlled_vocab_manager/iso_language_translator.rb
@@ -1,0 +1,27 @@
+module ControlledVocabManager
+  class IsoLanguageTranslator
+    
+    def self.language_list(format = :symbol)
+      language_hash = {}
+      if(format == :symbol)
+        ISO_639::ISO_639_1.each do |array|
+          language_hash[array[2].to_sym] = array[3]
+        end
+      elsif(format == :string)
+        ISO_639::ISO_639_1.each do |array|
+          language_hash[array[3]] = array[2].to_sym
+        end
+      end
+      language_hash
+    end
+
+    def self.find_by_name(name)
+      language_list(:string)[name.capitalize]
+    end
+
+    def self.find_by_symbol(symbol)
+      language_list(:symbol)[symbol] ||= "Language Not Found"
+    end
+
+  end
+end

--- a/lib/param_cleaner.rb
+++ b/lib/param_cleaner.rb
@@ -6,7 +6,7 @@ class ParamCleaner < Struct.new(:params)
 
   def cleaned_params
     params.each do |k,v|
-      new_params[k] = clean_value(v)
+      new_params[k] = clean_value(v) unless k == "language"
     end
     new_params
   end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe TermsController do
       allow(term_form).to receive(:save).and_return(save_success)
       allow(term).to receive(:id).and_return("test/test")
       allow(term).to receive(:attributes=)
-      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :midified])
+      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :modified])
       allow(term).to receive(:attributes).and_return(params[:vocabulary])
       allow(Vocabulary).to receive(:find)
       post :create, params
@@ -205,10 +205,11 @@ RSpec.describe TermsController do
     end
     let(:persist_success) { true }
     let(:persist_failure) { false }
-before do
+
+    before do
       allow_any_instance_of(TermFormRepository).to receive(:find).and_return(term_form)
       allow(term).to receive(:attributes=)
-      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :midified])
+      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :modified])
       allow(term).to receive(:attributes).and_return(params)
       allow(term).to receive(:persist!).and_return(persist_success)
       allow(term_form).to receive(:valid?).and_return(true)

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -109,12 +109,17 @@ RSpec.describe TermsController do
     let(:term) { instance_double("Term") }
     let(:params) do
       {
-        :vocabulary_id => "test",
         :term => {
-          "id" => "test",
-          :comment => ["Test"],
-          :label => ["Label"]
-        }
+          :id => "blah"
+        },
+        :vocabulary_id => "test",
+        :vocabulary => {
+          "id" => "testing",
+          :label => ["Test"],
+          :comment => ["Comment"],
+          :language => {
+            :label => ["en"],
+            :comment => ["en"]}}
       }
     end
     let(:save_success) { true }
@@ -123,7 +128,8 @@ RSpec.describe TermsController do
       allow(term_form).to receive(:save).and_return(save_success)
       allow(term).to receive(:id).and_return("test/test")
       allow(term).to receive(:attributes=)
-      allow(term).to receive(:attributes).and_return(params[:term])
+      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :midified])
+      allow(term).to receive(:attributes).and_return(params[:vocabulary])
       allow(Vocabulary).to receive(:find)
       post :create, params
     end
@@ -139,10 +145,16 @@ RSpec.describe TermsController do
     context "when blank arrays are passed in" do
       let(:params) do
         {
-          :vocabulary_id => "test",
           :term => {
+            :id => "blah"
+          },
+          :vocabulary_id => "test",
+          :vocabulary => {
             "id" => "test",
-            :label => [""]
+            :label => [""],
+            :language => {
+              :label => ["en"],
+            }
           }
         }
       end
@@ -184,27 +196,28 @@ RSpec.describe TermsController do
     let(:term_form) { TermForm.new(SetsAttributes.new(term), Term) }
     let(:params) do
       {
-        :term => {
-          :comment => ["Test"],
-          :label => ["Comment"]
-        }
+          :label => ["Test"],
+          :comment => ["Comment"],
+          :language => {
+            :label => ["en"],
+            :comment => ["en"]}
       }
     end
     let(:persist_success) { true }
     let(:persist_failure) { false }
-
-    before do
+before do
       allow_any_instance_of(TermFormRepository).to receive(:find).and_return(term_form)
       allow(term).to receive(:attributes=)
+      allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :midified])
       allow(term).to receive(:attributes).and_return(params)
       allow(term).to receive(:persist!).and_return(persist_success)
       allow(term_form).to receive(:valid?).and_return(true)
-      patch :update, :id => term.id, :term => params[:term]
+      patch :update, :id => term.id, :vocabulary => params
     end
     
     context "when the fields are edited" do
       it "should update the properties" do
-        expect(term).to have_received(:attributes=).with(params[:term])
+        expect(term).to have_received(:attributes=).with(params.except(:language))
       end
       it "should redirect to the updated term" do
         expect(response).to redirect_to("/ns/#{term.id}")
@@ -214,15 +227,12 @@ RSpec.describe TermsController do
     context "when the fields are edited and the update fails" do
       before do
         allow(term).to receive(:persist!).and_return(persist_failure)
-        patch :update, :id => term.id, :term => params[:term]
+        patch :update, :id => term.id, :vocabulary => params
       end
       it "should show the edit form" do
         expect(assigns(:term)).to eq term_form
         expect(response).to render_template("edit")
       end
-
     end
-
   end
-
 end

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -52,13 +52,18 @@ RSpec.describe VocabulariesController do
     let(:params) do
       {
         :comment => ["Test"],
-        :label => ["Comment"]
+        :label => ["Test"],
+        :language => {
+          :label => ["en"],
+          :comment => ["en"]
+        }
       }
     end
     let(:persist_success) { true }
 
     before do
       allow_any_instance_of(VocabularyFormRepository).to receive(:find).and_return(vocabulary_form)
+      allow(vocabulary).to receive(:blacklisted_language_properties).and_return([:id, :issued, :modified])
       allow(vocabulary).to receive(:attributes=)
       allow(vocabulary).to receive(:persist!).and_return(persist_success)
       allow(vocabulary_form).to receive(:valid?).and_return(true)
@@ -68,7 +73,7 @@ RSpec.describe VocabulariesController do
     
     context "when the fields are edited" do
       it "should update the properties" do
-        expect(vocabulary).to have_received(:attributes=).with(params).exactly(2).times
+        expect(vocabulary).to have_received(:attributes=).with({:comment=>[RDF::Literal("Test", :language => :en)], :label=>[RDF::Literal("Test", :language => :en)]}).exactly(1).times
       end
       it "should redirect to the updated term" do
         expect(response).to redirect_to("/ns/#{vocabulary.id}")
@@ -77,7 +82,10 @@ RSpec.describe VocabulariesController do
         let(:params) do
           {
             :comment => [""],
-            :label => ["Test"]
+            :label => ["Test"],
+              :language => {
+                :label => ["en"]
+              }
           }
         end
         it "should ignore them" do
@@ -129,10 +137,14 @@ RSpec.describe VocabulariesController do
 
   describe "POST create" do
     let(:vocabulary_params) do
-      {
-        :label => ["Test1"],
-        :comment => ["Test2"]
-      }
+        {
+          :label => ["test"],
+          :comment => ["blah"],
+          :language => {
+            :label => ["en"],
+            :comment => ["en"]
+          }
+        }
     end
     let(:vocabulary) { instance_double("Vocabulary") }
     let(:vocabulary_form) { VocabularyForm.new(SetsAttributes.new(vocabulary), Vocabulary) }
@@ -141,6 +153,7 @@ RSpec.describe VocabulariesController do
     before do
       allow_any_instance_of(VocabularyFormRepository).to receive(:new).and_return(vocabulary_form)
       allow(vocabulary_form).to receive(:save).and_return(save_success)
+      allow(vocabulary).to receive(:blacklisted_language_properties).and_return([:id, :issued, :modified])
       allow(vocabulary).to receive(:id).and_return("test")
       allow(vocabulary).to receive(:attributes=)
       allow(vocabulary).to receive(:attributes).and_return(vocabulary_params)
@@ -153,7 +166,11 @@ RSpec.describe VocabulariesController do
       let(:vocabulary_params) do
         {
           :label => ["test"],
-          :comment => [""]
+          :comment => [""],
+          :language => {
+            :label => ["en"],
+            :comment => ["en"]
+          }
         }
       end
       it "should not pass them to vocabulary" do

--- a/spec/decorators/sets_attributes_spec.rb
+++ b/spec/decorators/sets_attributes_spec.rb
@@ -4,12 +4,16 @@ RSpec.describe SetsAttributes do
   subject { SetsAttributes.new(term) }
   let(:term) { term_mock }
   let(:test_param) {{
-    "label" => ["blah"]
+    :label => ["blah"],
+    :language => {
+      :label => ['en']
+    }
   }}
   before do
     stub_repository
     allow(term).to receive(:attributes=)
     allow(term).to receive(:attributes).and_return(test_param)
+    allow(term).to receive(:blacklisted_language_properties).and_return([:id, :issued, :modified])
     allow(term).to receive(:valid?).and_return(true)
   end
 

--- a/spec/features/create_term_spec.rb
+++ b/spec/features/create_term_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Creating a vocabulary & term", :js => true do
     expect(vocabulary_create_page).to be_visible
     vocabulary_show_page = vocabulary_create_page.create
     
-    expect(get_vocab_statement_list[3].object.language).to eq :aa
+    expect(get_vocab_statement_list[3].object.language).to eq :en
     expect(vocabulary_show_page).to be_visible
 
     term_create_page = TermCreatePage.new("TestVocab")
@@ -20,7 +20,7 @@ RSpec.feature "Creating a vocabulary & term", :js => true do
     expect(term_create_page).to be_visible
     term_show_page = term_create_page.create
 
-    expect(get_term_statement_list[2].object.language).to eq :aa
+    expect(get_term_statement_list[2].object.language).to eq :en
     expect(term_show_page).to be_visible
 
   end

--- a/spec/lib/controlled_vocab_manager/iso_language_translator_spec.rb
+++ b/spec/lib/controlled_vocab_manager/iso_language_translator_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ControlledVocabManager::IsoLanguageTranslator do
-  let(:translator) {described_class.new}
+  let(:translator) {described_class}
 
   describe "#language_list" do
     context "When requesting a list with symbol access" do

--- a/spec/lib/controlled_vocab_manager/iso_language_translator_spec.rb
+++ b/spec/lib/controlled_vocab_manager/iso_language_translator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ControlledVocabManager::IsoLanguageTranslator do
+  let(:translator) {described_class.new}
+
+  describe "#language_list" do
+    context "When requesting a list with symbol access" do
+      it "should return a list of ISO_639 languages with symbol access" do
+        expect(translator.language_list(:symbol)).to be_kind_of Hash
+        expect(translator.language_list(:symbol).length).to eq ISO_639::ISO_639_1.length
+        expect(translator.language_list(:symbol)[:de]).to eq "German"
+      end
+    end
+    context "When requesting a list with string access" do
+      it "should return a list of ISO_639 languages with symbol access" do
+        expect(translator.language_list(:string)).to be_kind_of Hash
+        expect(translator.language_list(:string).length).to eq ISO_639::ISO_639_1.length
+        expect(translator.language_list(:string)["German"]).to eq :de
+      end
+    end
+    context "When requesting a list with no args" do
+      it "should default to symbol access" do
+        expect(translator.language_list[:de]).to eq "German"
+      end
+    end
+  end
+
+  describe "#find_by_name" do
+    it "should return a symbol for the language name" do
+      expect(translator.find_by_name("German")).to eq :de
+      expect(translator.find_by_name("german")).to eq :de
+    end
+  end
+
+  describe "#find_by_symbol" do
+    it "should return a string for the language symbol" do
+      expect(translator.find_by_symbol(:de)).to eq "German"
+      expect(translator.find_by_symbol(:banana)).to eq "Language Not Found"
+    end
+  end
+
+end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -138,4 +138,34 @@ RSpec.describe Term do
       end
     end
   end
+
+  describe "#property_language_list" do
+    context "When requesting a language associated with a property field" do
+      let(:label) {RDF::Literal("blah", :language => :en)}
+      let(:resource) do
+        t = Term.new("1")
+        t.label = [label]
+        t
+      end
+
+      it "should return the language associated with that field value" do
+        expect(resource.property_language_list(:label)).to eq ["English"]
+      end
+    end
+
+    context "When requesting a language associated with a property field with multiple values" do
+      let(:label1) {RDF::Literal("blah", :language => :en)}
+      let(:label2) {RDF::Literal("banana", :language => :zu)}
+      let(:resource) do
+        t = Term.new("1")
+        t.label = [label1, label2]
+        t
+      end
+
+      it "should return the language associated with that field value" do
+        expect(resource.property_language_list(:label)).to eq ["English", "Zulu"]
+      end
+    end
+
+  end
 end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe Term do
     end
   end
 
-  describe "#property_language_list" do
-    context "When requesting a language associated with a property field" do
+  describe "#values_for_property" do
+    context "When requesting a list of values for a property" do
       let(:label) {RDF::Literal("blah", :language => :en)}
       let(:resource) do
         t = Term.new("1")
@@ -148,12 +148,12 @@ RSpec.describe Term do
         t
       end
 
-      it "should return the language associated with that field value" do
-        expect(resource.property_language_list(:label)).to eq ["English"]
+      it "should return the list of values" do
+        expect(resource.values_for_property(:label)).to eq ["blah"]
       end
     end
 
-    context "When requesting a language associated with a property field with multiple values" do
+    context "When requesting a list of values with multiple values" do
       let(:label1) {RDF::Literal("blah", :language => :en)}
       let(:label2) {RDF::Literal("banana", :language => :zu)}
       let(:resource) do
@@ -162,10 +162,44 @@ RSpec.describe Term do
         t
       end
 
-      it "should return the language associated with that field value" do
-        expect(resource.property_language_list(:label)).to eq ["English", "Zulu"]
+      it "should return the list of values" do
+        expect(resource.values_for_property(:label)).to eq ["blah", "banana"]
+      end
+    end
+  end
+  describe "#literal_language_list_for_property" do
+    context "When requesting a list of literals with languages for a property" do
+      let(:label) {RDF::Literal("blah", :language => :en)}
+      let(:resource) do
+        t = Term.new("1")
+        t.label = [label]
+        t
+      end
+
+      it "should return the list" do
+        expect(resource.literal_language_list_for_property(:label).first.first).to be_kind_of RDF::Literal
+        expect(resource.literal_language_list_for_property(:label).first.second).to eq "English"
       end
     end
 
+    context "When requesting a list of literals with languages" do
+      let(:label1) {RDF::Literal("blah", :language => :en)}
+      let(:label2) {RDF::Literal("banana", :language => :zu)}
+      let(:resource) do
+        t = Term.new("1")
+        t.label = [label1, label2]
+        t
+      end
+
+      it "should return the list" do
+        expect(resource.values_for_property(:label)).to eq ["blah", "banana"]
+      end
+    end
+  end
+
+  describe "#language_from_symbol" do
+    it "should return a string from a language symbol" do
+      expect(resource.language_from_symbol(:zu)).to eq "Zulu"
+    end
   end
 end

--- a/spec/models/term_spec.rb
+++ b/spec/models/term_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Term do
   end
 
   describe "#values_for_property" do
-    context "When requesting a list of values for a property" do
+    context "When requesting a property's values when 1 value is present." do
       let(:label) {RDF::Literal("blah", :language => :en)}
       let(:resource) do
         t = Term.new("1")
@@ -148,12 +148,12 @@ RSpec.describe Term do
         t
       end
 
-      it "should return the list of values" do
+      it "should return the value in array form" do
         expect(resource.values_for_property(:label)).to eq ["blah"]
       end
     end
 
-    context "When requesting a list of values with multiple values" do
+    context "When requesting a property's values when multiple values are present" do
       let(:label1) {RDF::Literal("blah", :language => :en)}
       let(:label2) {RDF::Literal("banana", :language => :zu)}
       let(:resource) do
@@ -168,7 +168,7 @@ RSpec.describe Term do
     end
   end
   describe "#literal_language_list_for_property" do
-    context "When requesting a list of literals with languages for a property" do
+    context "When requesting a literal with a language for a property" do
       let(:label) {RDF::Literal("blah", :language => :en)}
       let(:resource) do
         t = Term.new("1")
@@ -176,7 +176,7 @@ RSpec.describe Term do
         t
       end
 
-      it "should return the list" do
+      it "should return the literal and language" do
         expect(resource.literal_language_list_for_property(:label).first.first).to be_kind_of RDF::Literal
         expect(resource.literal_language_list_for_property(:label).first.second).to eq "English"
       end

--- a/spec/support/pages/term_create_page.rb
+++ b/spec/support/pages/term_create_page.rb
@@ -7,8 +7,8 @@ class TermCreatePage < Struct.new(:vocabulary_id)
 
   def create
     fill_in "ID", :with => "banana"
-    fill_in "term_label", :with => "Test label"
-    fill_in "term_comment", :with => "Test comment"
+    fill_in "vocabulary[label][]", :with => "Test label"
+    fill_in "vocabulary[comment][]", :with => "Test comment"
     click_button "Create Term"
     TermShowPage.new(id)
   end

--- a/spec/support/pages/vocabulary_create_page.rb
+++ b/spec/support/pages/vocabulary_create_page.rb
@@ -7,7 +7,7 @@ class VocabularyCreatePage
 
   def create
     fill_in "ID", :with => "TestVocab"
-    fill_in "vocabulary_label", :with => "test"
+    fill_in "vocabulary[label][]", :with => "test"
     find(:xpath, "//input[@name = 'commit']").trigger("click")
     sleep 1
     VocabularyShowPage.new("TestVocab")

--- a/spec/views/terms/edit.html.erb_spec.rb
+++ b/spec/views/terms/edit.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "terms/edit" do
   end
   it "has inputs for all editable fields" do
     term.editable_fields.each do |attribute|
-      expect(rendered).to have_selector "input[name='term[#{attribute}][]']"
+      expect(rendered).to have_selector "input[name='vocabulary[#{attribute}][]']"
     end
   end
   it "should have an Update Term button" do

--- a/spec/views/terms/new.html.erb_spec.rb
+++ b/spec/views/terms/new.html.erb_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "terms/new" do
   end
   it "has inputs for all editable fields" do
     term.editable_fields.each do |attribute|
-      expect(rendered).to have_selector "input[name='term[#{attribute}][]']"
+      expect(rendered).to have_selector "input[name='vocabulary[#{attribute}][]']"
     end
   end
   it "should have a create term button" do

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -2,13 +2,17 @@ require 'rails_helper'
 
 RSpec.describe "terms/show" do
   let(:uri) { "http://opaquenamespace.org/ns/bla" }
-  let(:resource) { Term.new(uri) }
+  let(:resource) do 
+    Term.new(uri).tap do |t|
+      t.is_replaced_by = "http://opaquenamespace.org/ns/bla2"
+      t.label = ["a_label"] 
+    end
+  end
   let(:children) {}
 
   before do
     assign(:term, resource)
-    allow(resource).to receive(:fields).and_return([:label, :comment])
-    allow(resource).to receive(:get_values).with(anything) { |x| ["#{x}_string"] }
+    allow(resource).to receive(:fields).and_return([:label])
     allow(resource).to receive(:persisted?).and_return(true)
   end
 
@@ -87,13 +91,22 @@ RSpec.describe "terms/show" do
       expect(rendered).to_not have_link "Edit", :href => edit_term_path(:id => resource.id)
     end
   end
+  context "when visiting the show page" do
+    let(:resource) { 
+      t = Term.new(uri) 
+      t.is_replaced_by = "http://opaquenamespace.org/ns/bla2"
+      t.label = ["a_label", "another_label"]
+      t.comment = ["comment"]
+      t
+    }
+    it "should display all fields" do
 
-  it "should display all fields" do
-    render
+      render
 
-    resource.fields.each do |field|
-      expect(resource).to have_received(:get_values).with(field)
-      expect(rendered).to have_content("#{field}_string")
+      resource.fields.each do |field|
+        expect(rendered).to have_content(field)
+      end
+
     end
   end
 end

--- a/spec/views/vocabularies/edit.html.erb_spec.rb
+++ b/spec/views/vocabularies/edit.html.erb_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe "vocabularies/edit" do
 
   let(:id) { "Creator" }
-  let(:term) { Vocabulary.new(id) }
+  let(:term) do 
+    Vocabulary.new(id).tap do |t|
+      t.label = [RDF::Literal.new("blah", :language => :en)]
+    end
+  end
   before do
     allow(term).to receive(:persisted?).and_return(true)
     assign(:term, term)
@@ -18,6 +22,10 @@ RSpec.describe "vocabularies/edit" do
   it "should display the term URI" do
     expect(rendered).to have_content(term.rdf_subject.to_s)
   end
+  it "should display the language for a field" do
+    expect(rendered).to have_selector("#label_select_0")
+  end
+
   it "has inputs for all editable fields" do
     term.editable_fields.each do |attribute|
       expect(rendered).to have_selector "input[name='vocabulary[#{attribute}][]']"
@@ -25,5 +33,19 @@ RSpec.describe "vocabularies/edit" do
   end
   it "should have an Update Vocabulary button" do
     expect(rendered).to have_button("Update Vocabulary")
+  end
+
+  context "With two literals and languages" do
+    let(:term) do 
+      Vocabulary.new(id).tap do |t|
+        t.label = [RDF::Literal.new("blah", :language => :en), RDF::Literal.new("blahblah", :language => :zu)] 
+      end
+    end
+
+    it "should display the language for a field" do
+      expect(rendered).to have_selector("#label_select_0")
+      expect(rendered).to have_selector("#label_select_1")
+    end
+
   end
 end


### PR DESCRIPTION
Fixes #140 Fixes #141 Fixes #143 Fixes #142 Fixes #170

Extensive reworking how how languages are processed needed to occur due to it not supporting multiple languages. 

Since the tests were using sample parameters, these parameters had to emulate what is passed from the form. Since we have languages now, they needed to be added to all the params in the controller specs and elsewhere. 