### PR TITLE
Feature/remedy default text for active triple

### DIFF
--- a/app/views/terms/_term_row.html.erb
+++ b/app/views/terms/_term_row.html.erb
@@ -4,6 +4,9 @@
   <ul style="list-style: none;">
     <% if @term.blacklisted_language_properties.include?(field) %>
       <% @term.get_values(field).each do |term| %>
+        <!-- This is a temporary fix!!!!!!!!! Since this is an RDF error, the easiest way to fix this issue
+          is by checking if a terms value responds to rdf_label. We need to fix this as we are enabling rdf to 
+          work for the whole system -->
         <% if term.respond_to?(:rdf_label) %>
           <li><%= term.rdf_label.first %></li>
         <% else %>

--- a/app/views/terms/_term_row.html.erb
+++ b/app/views/terms/_term_row.html.erb
@@ -3,8 +3,12 @@
 <td>
   <ul style="list-style: none;">
     <% if @term.blacklisted_language_properties.include?(field) %>
-      <% @term.get_values(field).each do |t| %>
-        <li><%= t %></li>
+      <% @term.get_values(field).each do |term| %>
+        <% if term.respond_to?(:rdf_label) %>
+          <li><%= term.rdf_label.first %></li>
+        <% else %>
+          <li><%= term %></li>
+        <% end %>
       <% end %>
     <% else %>
       <% @term.literal_language_list_for_property(field).each do |t| %>


### PR DESCRIPTION
This PR Remedies the issue of default showing up instead of the uri. Since this only happens in the import process and is related to RDF being enabled throughout the system, we decided to patch this issue until we look at rdf support. For now, we are just getting the uri from the object and displaying it. 

In the import process, the uri's are being saved as ActiveTriples::Resources and only periodically. 

Fixes #158