### PR TITLE
Add db environment variable.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,4 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: <%= ENV['CVM_DB'] || 'db/production.sqlite3' %>


### PR DESCRIPTION
@wickr Here is my take on the solution of moving the database so when we redeploy it doesnt get deleted. I created an environment variable on the server with the path to the database. The path is shared/db/db_name.sqlite3. 