### PR TITLE
Added name to users.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ marmotta
 # Ignore coverage
 /coverage
 
+#Ignore dev git 
+/git_dev
+
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,6 @@ marmotta
 # Ignore coverage
 /coverage
 
-#Ignore dev git 
-/git_dev
-
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,7 +40,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
    def configure_sign_up_params
-     devise_parameter_sanitizer.for(:sign_up) << :institution
+     devise_parameter_sanitizer.for(:sign_up) << [:institution, :name]
    end
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -4,6 +4,7 @@
   <%= f.error_notification %>
 
   <div class="form-inputs">
+    <%= f.input :name, :required => true, :hint => "Please provide your first and last name" %>
     <%= f.input :email, required: true, autofocus: true %>
     <div class="institution-dropdown">
       <select name="user[institution]">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,7 +26,7 @@
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
               <i class="fa fa-user"></i>
-              <%= current_user.email %><span class="caret"></span>
+              <%= current_user.name || current_user.email %><span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
               <% if current_user.admin? %>

--- a/db/migrate/20160516223004_add_name_to_users.rb
+++ b/db/migrate/20160516223004_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160415173459) do
+ActiveRecord::Schema.define(version: 20160516223004) do
 
   create_table "users", force: true do |t|
     t.string   "email",                  default: "", null: false
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160415173459) do
     t.datetime "updated_at",                          null: false
     t.string   "role"
     t.string   "institution"
+    t.string   "name"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
Fixes #234 Fixes #254 This adds the addition of a new field to users. Now they have a required first and last name. There is a tip to let people know they need to add first and last and now their name is displayed instead of their email. If no name on a user it defaults to email instead.