### PR TITLE
Check for predicate type for type select

### DIFF
--- a/app/views/terms/_edit_form.html.erb
+++ b/app/views/terms/_edit_form.html.erb
@@ -1,6 +1,6 @@
 <p><%= term.rdf_subject %></p>
 
-<% if term.vocabulary? == false %>
+<% unless term.vocabulary? || term.predicate? %>
   <%= render :partial => "terms/term_types_select", :locals => { :disabled => true, :term => term } %>
 <% end %>
 <% term.editable_fields.each do |attribute| %>


### PR DESCRIPTION
Fixes #216 We just weren't checking for predicate along with vocabulary when rendering the select.