### PR TITLE
Feature/commit history

### DIFF
--- a/app/assets/stylesheets/template.css.scss
+++ b/app/assets/stylesheets/template.css.scss
@@ -66,6 +66,9 @@ textarea.tall {
   min-height: 350px;
 }
 
+.commit_hist, .commit_hist_diffs {
+  list-style-type: none;
+}
 /* Bootstrapified spinner */
 .glyphicon.spinning {
   margin-right: 10px;

--- a/app/controllers/concerns/git_interface.rb
+++ b/app/controllers/concerns/git_interface.rb
@@ -173,7 +173,14 @@ module GitInterface
       results.each do |commit|
         if commit[:message].include? "updating"
           diffs = get_diff(commit[:hash])
-          item = {:date => commit[:date], :author => commit[:author][:name], :diff => diffs }
+          newdiffs = []
+          #remove subject
+          diffs.each do |diff|
+            parts = diff.split("<")
+            newparts = parts.slice(0,1).concat(parts.slice(2, parts.length-1))
+            newdiffs << newparts.join("<")
+          end
+          item = {:date => commit[:date], :author => commit[:author][:name], :diff => newdiffs }
           formatted << item
           num_items = num_items + 1
         end

--- a/app/controllers/concerns/git_interface.rb
+++ b/app/controllers/concerns/git_interface.rb
@@ -145,11 +145,11 @@ module GitInterface
     repo = setup
     child = repo.lookup(commit1)
     commits = child.parents[0].diff(child)
-    commits.each_patch { |patch|
+    commits.each_patch do |patch|
       file = patch.delta.old_file[:path]
 
-      patch.each_hunk { |hunk|
-        hunk.each_line { |line|
+      patch.each_hunk do |hunk|
+        hunk.each_line do |line|
           case line.line_origin
           when :addition
             answer << "added: " + line.content
@@ -158,9 +158,9 @@ module GitInterface
           when :context
             #do nothing
           end
-        }
-      }
-    }
+        end
+      end
+    end
     answer
   end
 

--- a/app/controllers/concerns/git_interface.rb
+++ b/app/controllers/concerns/git_interface.rb
@@ -139,6 +139,7 @@ module GitInterface
     end
   end
 
+  #returns an array of triple as strings with "added" or "deleted" prefixes
   def get_diff(commit1)
     answer = []
     repo = setup

--- a/app/views/terms/_history.html.erb
+++ b/app/views/terms/_history.html.erb
@@ -1,10 +1,12 @@
 <div>
 <h3>Recent changes: </h3>
 <% @term.commit_history.each do |commit| %>
-  <p><%= commit[:date] %><br>
-     <%commit[:diff].each do |triple|%>
-    &nbsp;<%=triple%><br>
+  <ul class="commit_hist"><li><%= commit[:date] %></li>
+     <ul class="commit_hist_diffs">
+     <% commit[:diff].each do |triple| %>
+    <li><%= triple %></li>
     <% end %>
-    &nbsp; <%= commit[:author] %></p>
+    </ul>
+    <li><%= commit[:author] %></li></ul>
 <% end %>
 </div>

--- a/app/views/terms/_history.html.erb
+++ b/app/views/terms/_history.html.erb
@@ -1,5 +1,10 @@
 <div>
-<p>Term Author: <%= @term.commit_history[:author] %><br>
-Reviewed by: <%= @term.commit_history[:reviewer] %><br>
-Last modified: <%= @term.commit_history[:date_modified] %></p>
+<h3>Recent changes: </h3>
+<% @term.commit_history.each do |commit| %>
+  <p><%= commit[:date] %><br>
+     <%commit[:diff].each do |triple|%>
+    &nbsp;<%=triple%><br>
+    <% end %>
+    &nbsp; <%= commit[:author] %></p>
+<% end %>
 </div>

--- a/spec/controllers/git_interface_spec.rb
+++ b/spec/controllers/git_interface_spec.rb
@@ -19,14 +19,15 @@ RSpec.describe GitInterface do
   end
 
   describe "git process" do
-    let(:triple1) { "<http://opaquenamespace.org/ns/blah/foo><http://purl.org/dc/terms/date> '2016-05-04' .\n" }
-    let(:triple2) { "<http://opaquenamespace.org/ns/blah/foo><http://www.w3.org/2000/01/rdf-schema#label> 'foo' ." }
-    let(:triple3) { "<http://opaquenamespace.org/ns/blah/foo><http://www.w3.org/2000/01/rdf-schema#label> 'fooness' ." }
+    let(:subj) { "<http://opaquenamespace.org/ns/blah/foo>" }
+    let(:triple1) { "<http://purl.org/dc/terms/date> '2016-05-04' .\n" }
+    let(:triple2) { "<http://www.w3.org/2000/01/rdf-schema#label> 'foo' ." }
+    let(:triple3) { "<http://www.w3.org/2000/01/rdf-schema#label> 'fooness' ." }
 
     it "should commit, merge, and provide history" do
       #create blah/foo
       allow_any_instance_of(DummyController).to receive(:current_user).and_return(user1)
-      dummy_class.rugged_create("blah/foo",triple1+triple2,"creating")
+      dummy_class.rugged_create("blah/foo",subj+triple1+subj+triple2,"creating")
       repo = Rugged::Repository.new(ControlledVocabularyManager::Application::config.rugged_repo)
       repo.checkout("blah/foo")
       expect(repo.last_commit.message).to include("creating: blah/foo")
@@ -38,7 +39,7 @@ RSpec.describe GitInterface do
 
       #update blah/foo and merge
       allow_any_instance_of(DummyController).to receive(:current_user).and_return(user2)
-      dummy_class.rugged_create("blah/foo", triple1+triple3, "updating")
+      dummy_class.rugged_create("blah/foo", subj+triple1+subj+triple3, "updating")
       repo = Rugged::Repository.new(ControlledVocabularyManager::Application::config.rugged_repo)
       repo.checkout("blah/foo")
       expect(repo.last_commit.message).to include("updating: blah/foo")


### PR DESCRIPTION
fixes #246 

but I'm tempted to create a class that would handle formatting the triples once we start passing them around in string form, and removing some of that from GitInterface, so it could be in one place. could  stick the sort_stringify method in there too. 