### PR TITLE
move default type assign

### DIFF
--- a/app/services/graph_to_terms.rb
+++ b/app/services/graph_to_terms.rb
@@ -32,10 +32,11 @@ class GraphToTerms < Struct.new(:resource_factory, :graph)
           @klass = Title
         when Topic.type
           @klass = Topic
-        else
-          @klass = Term
         end
       end
+    end
+    if @klass.nil?
+      @klass = Term
     end
   end
 


### PR DESCRIPTION
Concept is being added to other term types; I ran across this while I was debugging review queue stuff. I think it happens here in graph_to_terms: the loop needs to test all of the triples before assigning default