### PR TITLE
dont checkout branch for history

### DIFF
--- a/spec/features/create_term_spec.rb
+++ b/spec/features/create_term_spec.rb
@@ -50,6 +50,7 @@ RSpec.feature "Create and update a Term", :js => true, :type => :feature do
     sleep 2
 
     term_review_show_page = term_review_index_page.select
+    expect(term_review_show_page.html).to match("added: &lt;http://schema.org/alternateName&gt; \"Test alt\"")
 
     term_review_show_page.mark
     expect(page).to have_content "#{vocabulary_id}/TestTerm has been saved and is ready for use."


### PR DESCRIPTION
dont checkout for review content

add test for review diff

This is related to issue 347, in that revgum suggested that we should limit how often the git index has to be locked.