### PR TITLE
handle git index lock prob in merge and views

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -3,6 +3,11 @@ include GitInterface
   
   def index
     @terms = review_list
+    if @terms.nil?
+      flash[:notice] = "Something went wrong, please notify a system administrator."
+      @terms = []
+    end
+    @terms
   end
 
   def show

--- a/spec/controllers/predicates_controller_spec.rb
+++ b/spec/controllers/predicates_controller_spec.rb
@@ -264,16 +264,27 @@ RSpec.describe PredicatesController do
       allow(predicate).to receive(:new_record?).and_return(true)
       allow_any_instance_of(PredicateForm).to receive(:save).and_return(save_success)
       allow_any_instance_of(GitInterface).to receive(:reassemble).and_return(predicate)
-      allow_any_instance_of(GitInterface).to receive(:rugged_merge)
-      get :mark_reviewed, :id =>params[:id]
-
     end
     context "when the item has been reviewed" do
+      before do
+        allow_any_instance_of(GitInterface).to receive(:rugged_merge)
+        get :mark_reviewed, :id =>params[:id]
+      end
       it "will redirect to review queue if asset is saved" do
         expect(flash[:notice]).to include("blah has been saved")
         expect(response).to redirect_to("/review")
       end
     end
+    context "when an error is raised inside rugged_merge" do
+      before do
+        allow_any_instance_of(GitInterface).to receive(:rugged_merge).and_return(0)
+        get :mark_reviewed, :id =>params[:id]
+      end
+      it "should show the flash error" do
+        expect(flash[:notice]).to include("Something went wrong")
+      end
+    end
+
   end
 
 

--- a/spec/controllers/review_controller_spec.rb
+++ b/spec/controllers/review_controller_spec.rb
@@ -19,16 +19,32 @@ RSpec.describe ReviewController do
       before do
         allow_any_instance_of(DummyController).to receive(:current_user).and_return(user)
         setup_for_review_test(dummy_class)
-        get :index
       end
       after do
         FileUtils.rm_rf(ControlledVocabularyManager::Application::config.rugged_repo)
       end
-      it "should work" do
-        expect(response).to be_success
-        expect(response).to render_template "index"
+      context "when things are ok" do
+        before do
+          get :index
+        end
+        it "should work" do
+          expect(response).to be_success
+          expect(response).to render_template "index"
+        end
       end
-
+      context "when git index is locked" do
+        before do
+          lock_git_index
+          get :index
+        end
+        after do
+          release_git_index
+        end
+        it "should handle it gracefully" do
+          expect(response).to be_success
+          expect(flash[:notice]).to include("Something went wrong")
+        end
+      end
     end
   end
 

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -359,16 +359,26 @@ RSpec.describe TermsController do
         allow(term).to receive(:type).and_return(nil)
         allow_any_instance_of(TermForm).to receive(:save).and_return(save_success)
         allow_any_instance_of(GitInterface).to receive(:reassemble).and_return(term)
-        allow_any_instance_of(GitInterface).to receive(:rugged_merge)
         allow(term).to receive(:term_uri_leaf).and_return(term_id)
         allow(term).to receive(:term_uri_vocabulary_id).and_return("test")
-        get :mark_reviewed, :id =>params[:id]
-
       end
       context "when the item has been reviewed" do
+        before do
+          allow_any_instance_of(GitInterface).to receive(:rugged_merge)
+          get :mark_reviewed, :id =>params[:id]
+        end
         it "will redirect to review queue if asset is saved" do
           expect(flash[:notice]).to include("test/blah has been saved")
           expect(response).to redirect_to("/review")
+        end
+      end
+      context "when an error is raised inside rugged_merge" do
+        before do
+          allow_any_instance_of(GitInterface).to receive(:rugged_merge).and_return(0)
+          get :mark_reviewed, :id =>params[:id]
+        end
+        it "should show the flash error" do
+          expect(flash[:notice]).to include("Something went wrong")
         end
       end
 

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -309,15 +309,26 @@ RSpec.describe VocabulariesController do
       allow(vocabulary).to receive(:new_record?).and_return(true)
       allow_any_instance_of(VocabularyForm).to receive(:save).and_return(save_success)
       allow_any_instance_of(GitInterface).to receive(:reassemble).and_return(vocabulary)
-      allow_any_instance_of(GitInterface).to receive(:rugged_merge)
-      get :mark_reviewed, :id =>params[:id]
-
     end
     context "when the item has been reviewed" do
+      before do
+        allow_any_instance_of(GitInterface).to receive(:rugged_merge)
+        get :mark_reviewed, :id =>params[:id]
+      end
       it "will redirect to review queue if asset is saved" do
         expect(flash[:notice]).to include("blah has been saved")
         expect(response).to redirect_to("/review")
       end
     end
+    context "when an error is raised inside rugged_merge" do
+      before do
+        allow_any_instance_of(GitInterface).to receive(:rugged_merge).and_return(0)
+        get :mark_reviewed, :id =>params[:id]
+      end
+      it "should show the flash error" do
+        expect(flash[:notice]).to include("Something went wrong")
+      end
+    end
+
   end
 end

--- a/spec/support/test_git_setup.rb
+++ b/spec/support/test_git_setup.rb
@@ -44,4 +44,15 @@ module TestGitSetup
     dummy_class.rugged_merge("blah")
   end
 
+  def lock_git_index
+    repo = Rugged::Repository.init_at(ControlledVocabularyManager::Application::config.rugged_repo)
+    branch = repo.branches.create("fake_branch", "HEAD")
+    repo.checkout(branch)
+    FileUtils.touch (ControlledVocabularyManager::Application::config.rugged_repo + "/.git/index.lock")
+  end
+  def release_git_index
+    File.unlink(ControlledVocabularyManager::Application::config.rugged_repo + "/.git/index.lock")
+    repo = Rugged::Repository.init_at(ControlledVocabularyManager::Application::config.rugged_repo)
+    repo.checkout('master')
+  end
 end


### PR DESCRIPTION
so this sort of addresses the git index lock problem
mainly by trying to handle it without blowing up
and also doing more to notify the user that something is wrong.
I don't, however, delete the index.lock if it exists, because that seems problematic?

but really, I'm hoping that since we stopped checking out branches every time someone sneezes, the lock prob will not be an issue