### PR TITLE
Fixes error where editor couldnt edit published vocabs

### DIFF
--- a/app/assets/javascripts/update_user_data_on_cached_page.js
+++ b/app/assets/javascripts/update_user_data_on_cached_page.js
@@ -6,9 +6,9 @@ $(document).ready(function(){
       $('nav.navbar').remove();
       $('body').prepend(html);
     });
-  $.ajax({ url: "/is_admin" })
+  $.ajax({ url: "/can_edit" })
     .done(function(json) {
-      if(json.admin) {
+      if(json.can_edit) {
         $(".hidden-unless-admin").show();
       }
     });

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,5 @@
 class Admin::UsersController < AdminController
   respond_to :html, :json
-  before_filter :require_admin
 
   def index
     @users = User.all

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,5 @@
 class AdminController < ApplicationController
-  before_filter :require_admin, :except => [:index, :show]
+  before_filter :require_admin, :except => [:index, :show, :edit, :update]
   
   def index
     

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,5 @@
 class AdminController < ApplicationController
-  before_filter :require_admin, :except => [:index, :show, :edit, :update]
+  before_filter :require_admin
   
   def index
     

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,7 @@ class HomeController < ApplicationController
     render partial: "shared/navbar", layout: false
   end
 
-  def admin
-    render json: { admin: current_user && current_user.admin? }
+  def can_edit
+    render json: { can_edit: current_user && current_user.editor? }
   end
 end

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -6,8 +6,8 @@ class TermsController < AdminController
 
   before_filter :skip_render_on_cached_page, only: :show
   caches_page :show
-  skip_before_filter :require_admin, :only => [:edit, :create, :new, :review_update, :mark_reviewed]
-  before_filter :require_editor, :only => [:edit, :create, :new]
+  skip_before_filter :require_admin
+  before_filter :require_editor
 
   def show
     @term = find_term

--- a/app/controllers/terms_controller.rb
+++ b/app/controllers/terms_controller.rb
@@ -6,7 +6,8 @@ class TermsController < AdminController
 
   before_filter :skip_render_on_cached_page, only: :show
   caches_page :show
-  skip_before_filter :require_admin, :only => [:review_update, :mark_reviewed]
+  skip_before_filter :require_admin, :only => [:edit, :create, :new, :review_update, :mark_reviewed]
+  before_filter :require_editor, :only => [:edit, :create, :new]
 
   def show
     @term = find_term

--- a/app/controllers/vocabularies_controller.rb
+++ b/app/controllers/vocabularies_controller.rb
@@ -2,7 +2,8 @@ class VocabulariesController < AdminController
   delegate :vocabulary_form_repository,  :all_vocabs_query, :to => :injector
   delegate :deprecate_vocabulary_form_repository, :to => :deprecate_injector
   include GitInterface
-  skip_before_filter :require_admin, :only => [:review_update, :mark_reviewed]
+  skip_before_filter :require_admin, :only => [:edit, :update, :review_update, :mark_reviewed]
+  before_filter :require_editor, :only => [:edit, :update]
 
   def index
     @vocabularies = all_vocabs_query.call

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,5 +55,5 @@ Rails.application.routes.draw do
   get "/review/*id", :to => "review#show", :as => "review_term"
 
   get "/nav", :to => "home#nav", :as => "nav"
-  get "/is_admin", :to => "home#admin", :as => "is_admin"
+  get "/can_edit", :to => "home#can_edit", :as => "can_edit"
  end

--- a/spec/controllers/terms_controller_spec.rb
+++ b/spec/controllers/terms_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TermsController do
   let(:resource) { term_mock }
   let(:injector) { TermInjector.new }
   let(:decorated_resource) { TermWithChildren.new(resource, injector.child_node_finder) }
-  let(:user) { User.create(:email => 'blah@blah.com', :password => "admin123",:role => "admin", :institution => "Oregon State University", :name => "Test")}
+  let(:user) { User.create(:email => 'blah@blah.com', :password => "admin123",:role => "admin editor reviewer", :institution => "Oregon State University", :name => "Test")}
 
   before do
     sign_in(user) if user
@@ -88,7 +88,7 @@ RSpec.describe TermsController do
       let(:user) { }
       it "should require login" do
         get_new
-        expect(response.body).to have_content("Only admin can access")
+        expect(response.body).to have_content("Only a user with proper permissions can access")
       end
     end
     context "when the vocabulary is not persisted" do
@@ -164,7 +164,7 @@ RSpec.describe TermsController do
           post :create, params
         end
         it "should require login" do
-          expect(response.body).to have_content("Only admin can access")
+          expect(response.body).to have_content("Only a user with proper permissions can access")
         end
       end
       context "when blank arrays are passed in" do

--- a/spec/controllers/vocabularies_controller_spec.rb
+++ b/spec/controllers/vocabularies_controller_spec.rb
@@ -4,7 +4,7 @@ require 'support/test_git_setup'
 
 RSpec.describe VocabulariesController do
   include TestGitSetup
-  let(:user) { User.create(:email => 'blah@blah.com', :password => "admin123",:role => "admin", :institution => "Oregon State University", :name => "Test")}
+  let(:user) { User.create(:email => 'blah@blah.com', :password => "admin123",:role => "admin reviewer editor", :institution => "Oregon State University", :name => "Test")}
 
   before do
     sign_in(user) if user

--- a/spec/features/import_rdf_term_spec.rb
+++ b/spec/features/import_rdf_term_spec.rb
@@ -7,8 +7,8 @@ end
 
 RSpec.feature "Import RDF", :js => true, :type => :feature do
   include TestGitSetup
-  given(:user) { User.create(:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin", :institution => "Oregon State University") }
-  let(:user_params) { {:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin", :institution => "Oregon State University"} }
+  given(:user) { User.create(:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin reviewer editor", :institution => "Oregon State University") }
+  let(:user_params) { {:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin reviewer editor", :institution => "Oregon State University"} }
   let(:dummy_class) { DummyController.new }
   let(:urlpred) { "http://opaquenamespace.org/ns/artSeries.jsonld" }
   let(:urlvoc) { "http://opaquenamespace.org/ns/TestVocabulary.jsonld" }

--- a/spec/features/load_rdf_term_spec.rb
+++ b/spec/features/load_rdf_term_spec.rb
@@ -7,8 +7,8 @@ end
 
 RSpec.feature "Load RDF", :js => true, :type => :feature do
   include TestGitSetup
-  given(:user) { User.create(:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin", :institution => "Oregon State University") }
-  let(:user_params) { {:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin", :institution => "Oregon State University"} }
+  given(:user) { User.create(:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin reviewer editor", :institution => "Oregon State University") }
+  let(:user_params) { {:email => 'admin@example.com', :name => "Jane Admin", :password => 'admin123', :role => "admin reviewer editor", :institution => "Oregon State University"} }
   let(:dummy_class) { DummyController.new }
   background do
     allow_any_instance_of(AdminController).to receive(:current_user).and_return(user)


### PR DESCRIPTION
There was an error where editors couldnt create new terms or edit pre existing vocabs.  This makes it so as an editor or any higher role, a user can create new terms edit pre-existing terms and edit vocabularies.