### PR TITLE
Adds relationship model with attributes and forms/repositories initial code.

### DIFF
--- a/app/forms/relationship_form.rb
+++ b/app/forms/relationship_form.rb
@@ -1,0 +1,19 @@
+class RelationshipForm < SimpleDelegator
+  include ActiveModel::Validations
+  validates_with *(TermValidations)
+
+  attr_reader :repository
+  def initialize(relationship, repository)
+    @repository = repository
+    __setobj__(relationship)
+  end
+
+  def is_valid?
+    valid?
+  end
+
+  def save
+    return false unless valid?
+    self.persist!
+  end
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -4,14 +4,14 @@ class Relationship < Term
 
   configure :type => RDF::URI("http://vivoweb.org/ontology/core#Relationship")
 
-  property :parents, :predicate => RDF::Vocab::SKOS.broader
-  property :children, :predicate => RDF::Vocab::SKOS.narrower
+  property :hier_parent, :predicate => RDF::Vocab::SKOS.broader
+  property :hier_child, :predicate => RDF::Vocab::SKOS.narrower
   property :date, :predicate => RDF::Vocab::DC.date
   property :comment, :predicate => RDF::RDFS.comment
 
   # Update the fields method with any new properties added to this model
   def fields
-    [:parents, :children, :date, :comment] | super
+    [:hier_parent, :hier_child, :date, :comment] | super
   end
 
   def self.option_text
@@ -23,7 +23,7 @@ class Relationship < Term
   end
 
   def self.visible_form_fields
-    %w[parents children date comment]
+    %w[hier_parent hier_child date comment]
   end
 
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,29 @@
+class Relationship < Term 
+
+  attr_accessor :commit_history
+
+  configure :type => RDF::URI("http://vivoweb.org/ontology/core#Relationship")
+
+  property :parents, :predicate => RDF::Vocab::SKOS.broader
+  property :children, :predicate => RDF::Vocab::SKOS.narrower
+  property :date, :predicate => RDF::Vocab::DC.date
+  property :comment, :predicate => RDF::RDFS.comment
+
+  # Update the fields method with any new properties added to this model
+  def fields
+    [:parents, :children, :date, :comment] | super
+  end
+
+  def self.option_text
+    "Relationship"
+  end
+
+  def self.uri
+    self.type.to_s
+  end
+
+  def self.visible_form_fields
+    %w[parents children date comment]
+  end
+
+end

--- a/app/repositories/relationship_form_repository.rb
+++ b/app/repositories/relationship_form_repository.rb
@@ -1,4 +1,4 @@
-# Repository that returns a decorated Vocabulary object with VocabularyForm
+# Repository that returns a decorated Relationship object with RelationshipForm
 # validations.
 class RelationshipFormRepository < Struct.new(:decorators)
   delegate :new, :find, :exists?, :to => :repository

--- a/app/repositories/relationship_form_repository.rb
+++ b/app/repositories/relationship_form_repository.rb
@@ -1,0 +1,20 @@
+# Repository that returns a decorated Vocabulary object with VocabularyForm
+# validations.
+class RelationshipFormRepository < Struct.new(:decorators)
+  delegate :new, :find, :exists?, :to => :repository
+
+  def repository
+    DecoratingRepository.new(decorators, Relationship)
+  end
+
+  private
+
+  def decorators
+    result = super || NullDecorator.new
+    DecoratorList.new(result, term_form_decorator)
+  end
+
+  def term_form_decorator
+    DecoratorWithArguments.new(RelationshipForm, StandardRepository.new(nil, Relationship))
+  end
+end

--- a/spec/forms/relationship_form_spec.rb
+++ b/spec/forms/relationship_form_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+WebMock.allow_net_connect!
+
+RSpec.describe RelationshipForm do
+  subject { RelationshipForm.new(term, repository) }
+  let(:term) do
+    t = Relationship.new(id)
+    t.attributes = params
+    t
+  end
+  let(:repository) { Relationship }
+  let(:id) { "term" }
+  let(:params) do
+    {
+      :comment => ["Comment"]
+    }
+  end
+
+  def id_exists(id, exists=true)
+    allow(term.class).to receive(:exists?).with(id).and_return(exists)
+  end
+
+  def stub_term_factory
+    allow(term).to receive(:attributes=)
+    allow(term).to receive(:fields).and_return([:comment])
+    term
+  end
+
+  describe "#editable_fields" do
+    it "should delegate to Term" do
+      term = stub_term_factory
+      allow(term).to receive(:editable_fields).and_return([:label])
+
+      expect(subject.editable_fields).to eq [:label]
+    end
+  end
+
+  describe "validations" do
+    let(:id) { "brandnew-blah" }
+    it "should be valid by default" do
+      allow(subject).to receive(:valid?).and_return(true)
+      expect(subject).to be_valid
+    end
+    context "when the term already exists" do
+      before do
+        id_exists(id)
+      end
+      it "should not be valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:id]).to include "already exists in the repository"
+      end
+    end
+    context "when the id is blank" do
+      let(:id) {""}
+      it "should not be valid" do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:id]).to include "can't be blank"
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when valid" do
+      it "should return true" do
+        allow(subject).to receive(:valid?).and_return(true)
+        expect(subject.save).to eq true
+      end
+    end
+    context "when invalid" do
+      let(:id) {""}
+      it "should return false" do
+        expect(subject.save).to eq false
+      end
+    end
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe Relationship do
+  let(:uri) { "http://opaquenamespace.org/ns/bla" }
+  let(:resource) { Relationship.new(uri) }
+
+  let(:id) { nil }
+
+  it "should be an AT::Resource" do
+    expect(Relationship < ActiveTriples::Resource).to be true
+  end
+
+  it "should instantiate" do
+    expect{Relationship.new}.not_to raise_error
+  end
+
+  context "when it is persisted" do
+    before do
+      resource.comment = "This is a comment"
+      resource.persist!
+    end
+    it "should be retrievable" do
+      expect(Relationship.find(uri)).not_to be_empty
+    end
+  end
+
+
+  it "should have a configured type" do
+    expect(resource.type).to eq [RDF::URI("http://vivoweb.org/ontology/core#Relationship")]
+  end
+
+  it "should have visible form fields" do
+    expect(Relationship.visible_form_fields).to eq %w[parents children date comment]
+  end
+
+  describe "#get_values" do
+    before do
+      resource.comment = "test"
+    end
+    it "should be able to return values" do
+      expect(resource.get_values(:comment)).to eq ["test"]
+    end
+  end
+
+  describe "#attributes=" do
+    context "with blank arrays" do
+      let(:attributes) do
+        {
+          :comment => ["bla"]
+        }
+      end
+      before do
+        resource.attributes = attributes
+      end
+      it "should do nothing" do
+        expect(resource.comment).to eq ["bla"]
+      end
+    end
+  end
+
+  describe "#id" do
+    context "with no id" do
+      let(:resource) { Term.new }
+      it "should be nil" do
+        expect(resource.id).to be_nil
+      end
+    end
+    context "with an id" do
+      let(:resource) { Term.new("bla/bla") }
+      before do
+        resource.persist!
+      end
+      it "should be just the id" do
+        expect(resource.id).to eq "bla/bla"
+      end
+    end
+  end
+
+  describe "validations" do
+    context "when not given a uri" do
+      let(:uri) { nil }
+      it "should be invalid" do
+        expect(resource).not_to be_valid
+      end
+    end
+    context "when given a URI" do
+      it "should be valid" do
+        expect(resource).to be_valid
+      end
+    end
+  end
+
+
+
+  it "should have additional fields" do
+    expect(resource.fields).to include :parents
+    expect(resource.fields).to include :children
+    expect(resource.fields).to include :date
+    expect(resource.fields).to include :comment
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Relationship do
   end
 
   it "should have visible form fields" do
-    expect(Relationship.visible_form_fields).to eq %w[parents children date comment]
+    expect(Relationship.visible_form_fields).to eq %w[hier_parent hier_child date comment]
   end
 
   describe "#get_values" do
@@ -93,8 +93,8 @@ RSpec.describe Relationship do
 
 
   it "should have additional fields" do
-    expect(resource.fields).to include :parents
-    expect(resource.fields).to include :children
+    expect(resource.fields).to include :hier_parent
+    expect(resource.fields).to include :hier_child
     expect(resource.fields).to include :date
     expect(resource.fields).to include :comment
   end


### PR DESCRIPTION
This adds the initial model for relationship and base code for the repository and relationship form objects. Relationship was not playing nicely with its own repository which was hanging me up for a little. So it inherits from Term so the default repository plays nicely. 

So im overriding the form fields to only use the ones we want.

Fixes #410 