### PR TITLE
Feature/generate id on new term

### DIFF
--- a/app/models/term_id.rb
+++ b/app/models/term_id.rb
@@ -6,6 +6,7 @@ class TermID
   attr_reader :id
 
   def initialize(id)
+    id ||= ControlledVocabManager::IdMinter.mint_id
     @id = id.to_s
   end
 

--- a/app/views/terms/_form_id.html.erb
+++ b/app/views/terms/_form_id.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :id, :wrapper => :vertical_input_group, :label => "ID" do %>
   <span class="input-group-addon"><%= @vocabulary.rdf_subject.to_s %>/</span>
-  <%= f.input_field :id, :class => "form-control", :value => @term.id.to_s.gsub(/^#{@vocabulary.id}\//,'') %>
+  <%= f.input_field :id, :class => "form-control", :value => @term.term_id.to_s.gsub(/^#{@vocabulary.id}\//,'') %>
   <%= hidden_field_tag 'vocabulary_id', @vocabulary.id %>
 <% end %>

--- a/lib/controlled_vocab_manager/id_minter.rb
+++ b/lib/controlled_vocab_manager/id_minter.rb
@@ -1,0 +1,14 @@
+module ControlledVocabManager
+  class IdMinter
+    class << self
+      def mint_id
+        generate_id
+      end
+
+      def generate_id
+        o = [('a'..'z'), ('A'..'Z'), (0..9)].map(&:to_a).flatten
+        (0...7).map { o[rand(o.length)] }.join
+      end
+    end
+  end
+end

--- a/lib/controlled_vocab_manager/id_minter.rb
+++ b/lib/controlled_vocab_manager/id_minter.rb
@@ -7,7 +7,7 @@ module ControlledVocabManager
 
       def generate_id
         o = [('a'..'z'), ('A'..'Z'), (0..9)].map(&:to_a).flatten
-        (0...7).map { o[rand(o.length)] }.join
+        (0...8).map { o[rand(o.length)] }.join
       end
     end
   end

--- a/spec/lib/controlled_vocab_manager/id_minter_spec.rb
+++ b/spec/lib/controlled_vocab_manager/id_minter_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe ControlledVocabManager::IdMinter do
     it "should generate an 8 digit alpha numeric hash" do
       expect(minter.generate_id.length).to eq 8
     end
+    it "should only include letters and numbers" do
+      expect(minter.generate_id).not_to include(' ', '_', '$', '&')
+    end
   end
 
 end

--- a/spec/lib/controlled_vocab_manager/id_minter_spec.rb
+++ b/spec/lib/controlled_vocab_manager/id_minter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ControlledVocabManager::IdMinter do
   let(:minter) {described_class}
 
-  define "#generate_id" do
+  describe "#generate_id" do
     it "should generate an 8 digit alpha numeric hash" do
       expect(minter.generate_id.length).to eq 8
     end

--- a/spec/lib/controlled_vocab_manager/id_minter_spec.rb
+++ b/spec/lib/controlled_vocab_manager/id_minter_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ControlledVocabManager::IdMinter do
+  let(:minter) {described_class}
+
+  define "#generate_id" do
+    it "should generate an 8 digit alpha numeric hash" do
+      expect(minter.generate_id.length).to eq 8
+    end
+  end
+
+end

--- a/spec/models/term_id_spec.rb
+++ b/spec/models/term_id_spec.rb
@@ -4,6 +4,16 @@ RSpec.describe TermID do
   subject { TermID.new(id) }
   let(:id) { "vocab" }
 
+  describe "#initialize" do
+    let(:subject_minted) { TermID.new(nil) }
+    it "should not be blank" do
+      expect(subject_minted.to_s).not_to be_empty
+    end
+    it "should be 8 characters long" do
+      expect(subject_minted.to_s.length).to eq 8
+    end
+  end
+
   describe "#to_s" do
     it "should be the string" do
       expect(subject.to_s).to eq id


### PR DESCRIPTION
Fixes #409

Per the comments in #409, decided to just have the system generate an ID for every new term, which can be changed/overridden if needed.