### PR TITLE
Add small helper to map flash types to bootstrap styles.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,10 @@
+module ApplicationHelper
+  def flash_class(level)
+    case level
+      when 'notice' then "alert alert-info"
+      when 'success' then "alert alert-success"
+      when 'error' then "alert alert-danger"
+      when 'alert' then "alert alert-warning"
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
       <div class="container">
         <div class="starter-template">
           <% flash.each do |key, value| %>
-            <%= content_tag :div, value, class: "flash #{key} alert-#{key} alert" %>
+            <%= content_tag :div, value, class: flash_class(key) %>
           <% end %>
           <%= yield %>
         </div>


### PR DESCRIPTION
Fixes #459 

![screenshot from 2018-05-03 16-46-02](https://user-images.githubusercontent.com/2293544/39607731-7fbc03d2-4ef1-11e8-9070-45e94733e5c8.png)
