### PR TITLE
Add bootstrap label to term type display. Fix CSS classes.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -38,11 +38,12 @@ select#term_type { margin-bottom: 10px; }
   padding-left: 350px;
 }
 
-.label-corporatename { background-color: #955c65; }
+.label-corporate-name { background-color: #955c65; }
 .label-title { background-color: #917295; }
 .label-topic { background-color: #575b95; }
 .label-geographic { background-color: #5b8395; }
 .label-concept { background-color: #6a958a; }
-.label-personalname { background-color: #60956d; }
+.label-personal-name { background-color: #60956d; }
+.label-local-collection { background-color: #159818; }
 
 .hidden-unless-admin { display: none; }

--- a/app/views/terms/_term_row_type.html.erb
+++ b/app/views/terms/_term_row_type.html.erb
@@ -2,7 +2,7 @@
 <th scope="row">Type:</th>
 <td>
   <ul style="list-style: none;">
-    <li><%= type %> </li>
+    <li><span class="label label-<%= type.parameterize %>" style="font-size: 90%"><%= type %></span></li>
   </ul>
 </td>
 </tr>

--- a/app/views/terms/_vocab_child.html.erb
+++ b/app/views/terms/_vocab_child.html.erb
@@ -2,7 +2,7 @@
   <td><%= link_to child.rdf_label.first, term_path(child.id) %></td>
   <td><span class="uri"><%= link_to child.rdf_subject.to_s, term_path(child.id) %></span></td>
   <td>
-    <span class="label label-warning label-<%= child.parameterized_type %>"><%= child.titleized_type %></span>
+    <span class="label label-<%= child.parameterized_type %>"><%= child.titleized_type %></span>
     <% if child.deprecated? %>
         <span class="label label-warning">Deprecated</span>
     <% end %>


### PR DESCRIPTION
Fixes #528 

Add bootstrap label with existing color classes to term show page.

Fixed 'personal-name' and 'corporate-name' class names to match what `parameterize` on type produces. They were just displaying the 'label-warning' color, so since that wasn't needed on this I removed it.

![image](https://user-images.githubusercontent.com/2293544/56303407-b1a04900-60f0-11e9-9d05-5703c6dd383f.png)

![image](https://user-images.githubusercontent.com/2293544/56303456-d1d00800-60f0-11e9-8772-f344262e28ae.png)

