### PR TITLE
Remove ARK and local fields from Deprecate edit form.

### DIFF
--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -107,7 +107,7 @@ class Term < ActiveTriples::Resource
   end
 
   def editable_fields_deprecate
-    fields - [:issued, :modified, :label, :comment, :date, :see_also, :is_defined_by, :same_as, :alternate_name]
+    fields - [:issued, :modified, :label, :comment, :date, :see_also, :is_defined_by, :same_as, :alternate_name, :ark, :local]
   end
 
   def to_param


### PR DESCRIPTION
Fixes #539 

![image](https://user-images.githubusercontent.com/2293544/58593029-be9b7680-821e-11e9-954b-7cb1f0ac0ae4.png)

Only Is Replaced By field is showing.
