### PR TITLE
Ensure that any value inserted into a language enabled field is a RDF::Literal

### DIFF
--- a/app/decorators/sets_attributes.rb
+++ b/app/decorators/sets_attributes.rb
@@ -5,11 +5,7 @@ class SetsAttributes < SimpleDelegator
       unless self.blacklisted_language_properties.include?(key.to_sym) 
         value_array = []
         value.each_with_index do |val, index|
-          if (MaybeURI.new(val).uri?)
-            value_array << MaybeURI.new(val).value
-          else
-            value_array << RDF::Literal(val, :language => form_params[:language][key][index]) unless form_params[:language][key].blank?
-          end
+          value_array << RDF::Literal(val, :language => form_params[:language][key][index]) unless form_params[:language][key].blank?
         end
         new_hash[key] = value_array unless key == :language
       end


### PR DESCRIPTION
This is a very simple fix that only casts values to RDF::Literals instead of checking to see if we want an RDF::Literal or an RDF::URI. Since all fields that have a language should be a literal, this fix adheres to that need. Instead of checking if a value is a uri or not, we assume all values for these language fields are strings and cast them to RDF::Literals.