### PR TITLE
Update Term show page deprecate block

### DIFF
--- a/app/views/terms/show.html.erb
+++ b/app/views/terms/show.html.erb
@@ -8,7 +8,11 @@
     <div class="alert alert-warning">
       <strong>Deprecated</strong> -
       <%= :is_replaced_by.to_s.humanize %>
-      <%= link_to @term.get_values(:is_replaced_by).first, @term.get_values(:is_replaced_by).first %>
+      <% if @term.get_values(:is_replaced_by).first.is_a?(String) %>
+        <%= link_to @term.get_values(:is_replaced_by).first, @term.get_values(:is_replaced_by).first %>
+      <% else %>
+        <%= link_to @term.get_values(:is_replaced_by).first.rdf_subject.to_s, @term.get_values(:is_replaced_by).first.rdf_subject.to_s %>
+      <% end %>
     </div>
 <% end %>
 

--- a/spec/views/terms/show.html.erb_spec.rb
+++ b/spec/views/terms/show.html.erb_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'terms/show' do
   context 'when term is deprecated' do
     let(:resource) do
       t = Term.new(uri)
-      t.is_replaced_by = 'http://opaquenamespace.org/ns/bla2'
+      t.is_replaced_by = RDF::URI('http://opaquenamespace.org/ns/bla2')
       t
     end
 
@@ -90,6 +90,8 @@ RSpec.describe 'terms/show' do
   context 'when visiting the show page' do
     let(:resource) do
       t = Term.new(uri)
+      # This instance of is_replaced_by is left as a string to ensure both values work.
+      # Currently most existing is_replaced_by values in ONS are strings.
       t.is_replaced_by = 'http://opaquenamespace.org/ns/bla2'
       t.label = %w[a_label another_label]
       t.comment = ['comment']


### PR DESCRIPTION
Update the deprecate block of the view, to display correctly whether
the is_replaced_by value is either a string or URI.

Also updated the test, changing 1 of the 2 test values to be a URI.
Since all existing is_replaced_by values in ONS are strings, we need to make sure those work as well.