### PR TITLE
Add same_as property, save value as URI.

### DIFF
--- a/lib/tasks/csv_to_jsonld.rake
+++ b/lib/tasks/csv_to_jsonld.rake
@@ -143,3 +143,7 @@ end
 def comment(id, graph, payload)
   graph << RDF::Statement.new(id, RDF::RDFS.comment, RDF::Literal.new(payload, :language => :en)) if payload
 end
+
+def same_as(id, graph, payload)
+  graph << RDF::Statement.new(id, RDF::OWL.sameAs, RDF::URI(payload)) if payload
+end


### PR DESCRIPTION
Fixes #580 

This worked for the new name imports that had it, such as: http://opaquenamespace.org/ns/creator/GarrisonJeannie